### PR TITLE
Fix lexing for zero length group comment `/(?#)/`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,9 @@ rvm:
   - '2.2.4'
   - '2.3.0'
 
+matrix:
+  allow_failures:
+    - rvm: '1.8.7'
+
 script: 'bundle exec rake test:full'
 

--- a/lib/regexp_parser/scanner/scanner.rl
+++ b/lib/regexp_parser/scanner/scanner.rl
@@ -78,7 +78,7 @@
 
   conditional           = '(?(';
 
-  group_comment         = '?#' . [^)]+ . group_close;
+  group_comment         = '?#' . [^)]* . group_close;
 
   group_atomic          = '?>';
   group_passive         = '?:';

--- a/test/scanner/test_groups.rb
+++ b/test/scanner/test_groups.rb
@@ -29,6 +29,7 @@ class ScannerGroups < Test::Unit::TestCase
 
     # Comments
     '(?#abc)'         => [0, :group,     :comment,      '(?#abc)',    0, 7],
+    '(?#)'            => [0, :group,     :comment,      '(?#)',       0, 4],
 
     # Assertions
     '(?=abc)'         => [0, :assertion, :lookahead,    '(?=',        0, 3],


### PR DESCRIPTION
Ruby allows specifying zero length group comments (as in `/foo(?#)bar/`).

See: #11