### PR TITLE
Fix parse of escape:codepoint_list

### DIFF
--- a/lib/regexp_parser/syntax/ruby/1.9.1.rb
+++ b/lib/regexp_parser/syntax/ruby/1.9.1.rb
@@ -15,7 +15,7 @@ module Regexp::Syntax
         implements :backref, Backreference::All +
           SubexpressionCall::All
 
-        implements :escape, CharacterType::Hex
+        implements :escape, CharacterType::Hex + Escape::Unicode
 
         implements :property,
           UnicodeProperty::V190

--- a/lib/regexp_parser/syntax/tokens/escape.rb
+++ b/lib/regexp_parser/syntax/tokens/escape.rb
@@ -11,6 +11,8 @@ module Regexp::Syntax
       ASCII = [:bell, :backspace, :escape, :form_feed, :newline, :carriage,
                :space, :tab, :vertical_tab]
 
+      Unicode = [:codepoint_list]
+
       Meta  = [:dot, :alternation,
                :zero_or_one, :zero_or_more, :one_or_more,
                :bol, :eol,

--- a/test/parser/test_escapes.rb
+++ b/test/parser/test_escapes.rb
@@ -25,6 +25,9 @@ class TestParserEscapes < Test::Unit::TestCase
     /a\)c/    => [1, :escape,   :group_close,       EscapeSequence::Literal],
     /a\{c/    => [1, :escape,   :interval_open,     EscapeSequence::Literal],
     /a\}c/    => [1, :escape,   :interval_close,    EscapeSequence::Literal],
+
+    # unicode escapes
+    /a\u{9879}/ => [1, :escape, :codepoint_list,    EscapeSequence::Literal],
   }
 
   count = 0

--- a/test/syntax/ruby/test_1.9.1.rb
+++ b/test/syntax/ruby/test_1.9.1.rb
@@ -10,7 +10,7 @@ class TestSyntaxRuby_V191 < Test::Unit::TestCase
   tests = {
     :implements => {
       :escape => [
-        Escape::Backreference + Escape::ASCII + Escape::Meta
+        Escape::Backreference + Escape::ASCII + Escape::Meta + Escape::Unicode
       ].flatten,
 
       :quantifier => [


### PR DESCRIPTION
* Adds support to 1.9 syntax
* Adds regression test for parsing
* Adds test asserting that ruby 1.9 supports this syntax

Fixes #13