### PR TITLE
Fix parsing of /\xFF/n (hex:escape)

### DIFF
--- a/lib/regexp_parser/syntax/ruby/1.9.1.rb
+++ b/lib/regexp_parser/syntax/ruby/1.9.1.rb
@@ -15,7 +15,7 @@ module Regexp::Syntax
         implements :backref, Backreference::All +
           SubexpressionCall::All
 
-        implements :escape, Escape::Unicode
+        implements :escape, Escape::Unicode + Escape::Hex
 
         implements :type, CharacterType::Hex
 

--- a/lib/regexp_parser/syntax/tokens/escape.rb
+++ b/lib/regexp_parser/syntax/tokens/escape.rb
@@ -21,6 +21,8 @@ module Regexp::Syntax
                :set_open, :set_close,
                :baclslash]
 
+      Hex   = [:hex]
+
       All   = Basic + Backreference + ASCII + Meta
       Type  = :escape
     end

--- a/test/parser/test_escapes.rb
+++ b/test/parser/test_escapes.rb
@@ -28,6 +28,9 @@ class TestParserEscapes < Test::Unit::TestCase
 
     # unicode escapes
     /a\u{9879}/ => [1, :escape, :codepoint_list,    EscapeSequence::Literal],
+
+     # hex escapes
+    /a\xFF/n =>  [1, :escape, :hex,                 EscapeSequence::Literal],
   }
 
   tests.each_with_index do |(pattern, (index, type, token, klass)), count|


### PR DESCRIPTION
A previous commit (9803fb2) fixed improper parsing of `/\h/` but unintentionally dropped support for multibyte hex escapes.