### PR TITLE
Remove warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,22 +399,22 @@ _A special task 'test:full' generates the scanner's code from the ragel source f
 runs all the tests. This task requires ragel to be installed._
 
 
-The tests use ruby's test/unit, so they can also be run with:
+The tests use ruby's test/unit. They can also be run with:
 
 ```
-ruby -Ilib test/test_all.rb
+bin/test
 ```
 
-This is useful when there is a need to focus on specific test files, for example:
+The test runner accepts all arguments accepted by test/unit.  You can run a specific test like so:
 
 ```
-ruby -Ilib test/scanner/test_properties.rb
+bin/test test/scanner/test_properties.rb
 ```
 
 It is sometimes helpful during development to focus on a specific test case, for example:
 
 ```
-ruby -Ilib test/expression/test_base.rb -n test_expression_to_re
+bin/test test/expression/test_base.rb -n test_expression_to_re
 ```
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -15,39 +15,13 @@ RAGEL_SOURCE_FILES = %w{scanner} # scanner.rl includes property.rl
 Bundler::GemHelper.install_tasks
 
 
-task :default => [:test]
-
-Rake::TestTask.new('test') do |t|
-  if t.respond_to?(:description)
-    t.description = "Run all unit tests under the test directory"
-  end
-
-  t.libs << "test"
-  t.test_files = FileList['test/test_all.rb']
-end
+task :default => [:'test:full']
 
 namespace :test do
-  %w{scanner lexer parser expression syntax}.each do |component|
-    Rake::TestTask.new(component) do |t|
-      if t.respond_to?(:description)
-        t.description = "Run all #{component} unit tests under the test/#{component} directory"
-      end
-
-      t.libs << "test"
-      t.test_files = ["test/#{component}/test_all.rb"]
-    end
-  end
-
-  Rake::TestTask.new('full' => 'ragel:rb') do |t|
-    if t.respond_to?(:description)
-      t.description = "Regenerate the scanner and run all unit tests under the test directory"
-    end
-
-    t.libs << "test"
-    t.test_files = FileList['test/test_all.rb']
+  task full: :'ragel:rb' do
+    sh 'bin/test'
   end
 end
-
 
 namespace :ragel do
   desc "Process the ragel source files and output ruby code"

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
+
+require 'yaml'
+
+require_relative '../test/support/disable_autotest'
+require_relative '../test/support/warning_extractor'
+require_relative '../test/support/runner'
+
+tests = ARGV.empty? ? %w[test/test_all.rb] : ARGV
+warning_whitelist = Set.new(
+  YAML.load_file(File.expand_path('../../test/warnings.yml', __FILE__))
+)
+
+RegexpParserTest::Runner.new(tests, warning_whitelist).run

--- a/lib/regexp_parser/scanner/property.rl
+++ b/lib/regexp_parser/scanner/property.rl
@@ -581,8 +581,6 @@
       # Unicode blocks
       when 'inalphabeticpresentationforms'
         self.emit(type, :block_inalphabetic_presentation_forms,           text, ts-1, te)
-      when 'inalphabeticpresentationforms'
-        self.emit(type, :block_inalphabetic_presentation_forms,           text, ts-1, te)
       when 'inarabicpresentationforms-a'
         self.emit(type, :block_inarabic_presentation_forms_a,             text, ts-1, te)
       when 'inarabicpresentationforms-b'

--- a/lib/regexp_parser/scanner/scanner.rl
+++ b/lib/regexp_parser/scanner/scanner.rl
@@ -281,7 +281,6 @@
       fhold;
       fnext character_set;
       fcall unicode_property;
-      fret;
     };
 
     # special case exclusion of escaped dash, could be cleaner.
@@ -409,7 +408,7 @@
     property_char > (escaped_alpha, 2) {
       fhold;
       fnext main;
-      fcall unicode_property; fret;
+      fcall unicode_property;
     };
 
     (any -- non_literal_escape) > (escaped_alpha, 1)  {

--- a/lib/regexp_parser/scanner/scanner.rl
+++ b/lib/regexp_parser/scanner/scanner.rl
@@ -832,7 +832,7 @@ module Regexp::Scanner
   # This method may raise errors if a syntax error is encountered.
   # --------------------------------------------------------------------------
   def self.scan(input_object, &block)
-    top, stack = 0, []
+    @literal, top, stack = nil, 0, []
 
     if input_object.is_a?(Regexp)
       input    = input_object.source

--- a/lib/regexp_parser/token.rb
+++ b/lib/regexp_parser/token.rb
@@ -12,6 +12,12 @@ class Regexp
   ].freeze
 
   Token = Struct.new(*TOKEN_KEYS) do
+    def initialize(*)
+      super
+
+      @previous = @next = nil
+    end
+
     def offset
       [self.ts, self.te]
     end

--- a/test/expression/test_base.rb
+++ b/test/expression/test_base.rb
@@ -65,7 +65,7 @@ class ExpressionBase < Test::Unit::TestCase
     assert_equal '@0+12', root.coded_offset
 
     # All top level offsets
-    checks = [
+    [
       [ '@0+1', '^'         ],
       [ '@1+2', 'a*'        ],
       [ '@3+8', '(b+(c?))'  ],

--- a/test/expression/test_conditionals.rb
+++ b/test/expression/test_conditionals.rb
@@ -32,7 +32,6 @@ class ExpressionConditionals < Test::Unit::TestCase
   def test_expression_conditional_level_one
     condition = @cond_1.condition
     branch_1  = @cond_1.branches.first
-    branch_2  = @cond_1.branches.last
 
     # Condition
     assert_equal true,  is_conditional_condition?(condition)

--- a/test/lexer/test_conditionals.rb
+++ b/test/lexer/test_conditionals.rb
@@ -31,7 +31,7 @@ class LexerConditionals < Test::Unit::TestCase
     regexp = /((?<A>a)(?<B>(?(<A>)b|((?(<B>)[e-g]|[h-j])))))/
     tokens = RL.lex(regexp)
 
-    expected = [
+    [
       [ 0, :group,       :capture,          '(',       0,  1, 0, 0, 0],
       [ 1, :group,       :named,            '(?<A>',   1,  6, 1, 0, 0],
 
@@ -70,7 +70,7 @@ class LexerConditionals < Test::Unit::TestCase
     regexp = /(a(b(c)))(?(1)(?(2)(?(3)d|e))|(?(3)(?(2)f|g)|(?(1)f|g)))/
     tokens = RL.lex(regexp)
 
-    expected = [
+    [
       [ 9, :conditional, :open,       '(?',    9, 11, 0, 0, 0],
       [10, :conditional, :condition,  '(1)',  11, 14, 0, 0, 1],
 

--- a/test/parser/test_quantifiers.rb
+++ b/test/parser/test_quantifiers.rb
@@ -46,7 +46,7 @@ class TestRegexpParserQuantifiers < Test::Unit::TestCase
     assert_equal true,          exp.quantified?
     assert_equal :zero_or_more, exp.quantifier.token
     assert_equal 0,             exp.quantifier.min
-    assert_equal -1,            exp.quantifier.max
+    assert_equal(-1,            exp.quantifier.max)
     assert_equal :greedy,       exp.quantifier.mode
   end
 
@@ -57,7 +57,7 @@ class TestRegexpParserQuantifiers < Test::Unit::TestCase
     assert_equal true,          exp.quantified?
     assert_equal :zero_or_more, exp.quantifier.token
     assert_equal 0,             exp.quantifier.min
-    assert_equal -1,            exp.quantifier.max
+    assert_equal(-1,            exp.quantifier.max)
     assert_equal :reluctant,    exp.quantifier.mode
     assert_equal true,          exp.reluctant?
   end
@@ -69,7 +69,7 @@ class TestRegexpParserQuantifiers < Test::Unit::TestCase
     assert_equal true,          exp.quantified?
     assert_equal :zero_or_more, exp.quantifier.token
     assert_equal 0,             exp.quantifier.min
-    assert_equal -1,            exp.quantifier.max
+    assert_equal(-1,            exp.quantifier.max)
     assert_equal :possessive,   exp.quantifier.mode
     assert_equal true,          exp.possessive?
   end
@@ -82,7 +82,7 @@ class TestRegexpParserQuantifiers < Test::Unit::TestCase
     assert_equal true,          exp.quantified?
     assert_equal :one_or_more,  exp.quantifier.token
     assert_equal 1,             exp.quantifier.min
-    assert_equal -1,            exp.quantifier.max
+    assert_equal(-1,            exp.quantifier.max)
     assert_equal :greedy,       exp.quantifier.mode
   end
 
@@ -93,7 +93,7 @@ class TestRegexpParserQuantifiers < Test::Unit::TestCase
     assert_equal true,          exp.quantified?
     assert_equal :one_or_more,  exp.quantifier.token
     assert_equal 1,             exp.quantifier.min
-    assert_equal -1,            exp.quantifier.max
+    assert_equal(-1,            exp.quantifier.max)
     assert_equal :reluctant,    exp.quantifier.mode
     assert_equal true,          exp.reluctant?
   end
@@ -105,7 +105,7 @@ class TestRegexpParserQuantifiers < Test::Unit::TestCase
     assert_equal true,          exp.quantified?
     assert_equal :one_or_more,  exp.quantifier.token
     assert_equal 1,             exp.quantifier.min
-    assert_equal -1,            exp.quantifier.max
+    assert_equal(-1,            exp.quantifier.max)
     assert_equal :possessive,   exp.quantifier.mode
     assert_equal true,          exp.possessive?
   end
@@ -154,7 +154,7 @@ class TestRegexpParserQuantifiers < Test::Unit::TestCase
     assert_equal true,      exp.quantified?
     assert_equal :interval, exp.quantifier.token
     assert_equal 2,         exp.quantifier.min
-    assert_equal -1,        exp.quantifier.max
+    assert_equal(-1,        exp.quantifier.max)
     assert_equal :greedy,   exp.quantifier.mode
   end
 
@@ -166,7 +166,7 @@ class TestRegexpParserQuantifiers < Test::Unit::TestCase
     assert_equal :interval,   exp.quantifier.token
     assert_equal '{2,}?',     exp.quantifier.text
     assert_equal 2,           exp.quantifier.min
-    assert_equal -1,          exp.quantifier.max
+    assert_equal(-1,          exp.quantifier.max)
     assert_equal :reluctant,  exp.quantifier.mode
     assert_equal true,        exp.reluctant?
   end
@@ -179,7 +179,7 @@ class TestRegexpParserQuantifiers < Test::Unit::TestCase
     assert_equal :interval,   exp.quantifier.token
     assert_equal '{3,}+',     exp.quantifier.text
     assert_equal 3,           exp.quantifier.min
-    assert_equal -1,          exp.quantifier.max
+    assert_equal(-1,          exp.quantifier.max)
     assert_equal :possessive, exp.quantifier.mode
     assert_equal true,        exp.possessive?
   end

--- a/test/parser/test_sets.rb
+++ b/test/parser/test_sets.rb
@@ -11,7 +11,7 @@ class TestParserSets < Test::Unit::TestCase
 
     assert_equal true,  exp.quantified?
     assert_equal 1,     exp.quantifier.min
-    assert_equal -1,    exp.quantifier.max
+    assert_equal(-1,    exp.quantifier.max)
   end
 
   def test_parse_set_posix_class

--- a/test/scanner/test_escapes.rb
+++ b/test/scanner/test_escapes.rb
@@ -13,7 +13,7 @@ class ScannerEscapes < Test::Unit::TestCase
     /c\tt/            => [1, :escape,  :tab,              '\t',             1,  3],
     /c\vt/            => [1, :escape,  :vertical_tab,     '\v',             1,  3],
 
-    /c\qt/            => [1, :escape,  :literal,          '\q',             1,  3],
+    'c\qt'            => [1, :escape,  :literal,          '\q',             1,  3],
 
     'a\012c'          => [1, :escape,  :octal,            '\012',           1,  5],
     'a\0124'          => [1, :escape,  :octal,            '\012',           1,  5],

--- a/test/support/disable_autotest.rb
+++ b/test/support/disable_autotest.rb
@@ -1,0 +1,8 @@
+require 'test/unit/autorunner'
+
+module Test::Unit
+  class AutoRunner
+    def self.need_auto_run?
+    end
+  end
+end

--- a/test/support/runner.rb
+++ b/test/support/runner.rb
@@ -1,0 +1,41 @@
+require 'pathname'
+
+module RegexpParserTest
+  class Runner
+    def initialize(arguments, warning_whitelist)
+      @arguments = arguments
+      @warning_whitelist = warning_whitelist
+    end
+
+    def run
+      test_status = nil
+
+      Warning::Filter.new(warning_whitelist).assert_expected_warnings_only do
+        setup
+        test_status = run_test_unit
+      end
+
+      test_status
+    end
+
+    private
+
+    def setup
+      $VERBOSE = true
+
+      test_files.each(&method(:require))
+    end
+
+    def run_test_unit
+      Test::Unit::AutoRunner.run
+    end
+
+    def test_files
+      arguments
+        .map { |path| Pathname.new(path).expand_path.freeze }
+        .select(&:file?)
+    end
+
+    attr_reader :arguments, :warning_whitelist
+  end
+end

--- a/test/support/warning_extractor.rb
+++ b/test/support/warning_extractor.rb
@@ -1,0 +1,59 @@
+require 'set'
+
+module RegexpParserTest
+  class Warning
+    class UnexpectedWarnings < StandardError
+      MSG = 'Unexpected warnings: %s'.freeze
+
+      def initialize(warnings)
+        super(MSG % warnings.join("\n"))
+      end
+    end
+
+    class Filter
+      def initialize(whitelist)
+        @whitelist = whitelist
+      end
+
+      def assert_expected_warnings_only
+        original = $stderr
+        $stderr  = Extractor.new(original, @whitelist)
+
+        yield
+
+        assert_no_warnings($stderr.warnings)
+      ensure
+        $stderr = original
+      end
+
+    private
+
+      def assert_no_warnings(warnings)
+        fail UnexpectedWarnings, warnings.to_a if warnings.any?
+      end
+    end
+
+    class Extractor < DelegateClass(IO)
+      PATTERN = /\A(?:.+):(?:\d+): warning: (?:.+)\n\z/.freeze
+
+      def initialize(io, whitelist)
+        @whitelist = whitelist
+        @warnings  = Set.new
+        super(io)
+      end
+
+      def write(message)
+        return super if PATTERN !~ message
+
+        warning = message.chomp
+        @warnings << warning if @whitelist.none?(&warning.method(:end_with?))
+
+        self
+      end
+
+      def warnings
+        @warnings.dup.freeze
+      end
+    end
+  end
+end

--- a/test/syntax/ruby/test_1.9.3.rb
+++ b/test/syntax/ruby/test_1.9.3.rb
@@ -20,8 +20,6 @@ class TestSyntaxRuby_V193 < Test::Unit::TestCase
   }
 
   tests.each do |method, types|
-    expected = method == :excludes ? false : true
-
     types.each do |type, tokens|
       tokens.each do |token|
         define_method "test_syntax_ruby_v193_#{method}_#{type}_#{token}" do

--- a/test/warnings.yml
+++ b/test/warnings.yml
@@ -1,63 +1,16 @@
 ---
+# Unused variable emitted by ragel
 - "lib/regexp_parser/scanner.rb:1646: warning:
   assigned but unused variable - testEof"
-- "test/scanner/test_escapes.rb:16: warning:
-  Unknown escape \\q is ignored: /c\\qt/"
-- "test/syntax/ruby/test_1.9.3.rb:23: warning:
-  assigned but unused variable - expected"
-- "test/lexer/test_conditionals.rb:34: warning:
-  assigned but unused variable - expected"
-- "test/lexer/test_conditionals.rb:73: warning:
-  assigned but unused variable - expected"
-- "test/parser/test_quantifiers.rb:49: warning:
-  ambiguous first argument; put parentheses or a space even after `-' operator"
-- "test/parser/test_quantifiers.rb:60: warning:
-  ambiguous first argument; put parentheses or a space even after `-' operator"
-- "test/parser/test_quantifiers.rb:72: warning:
-  ambiguous first argument; put parentheses or a space even after `-' operator"
-- "test/parser/test_quantifiers.rb:85: warning:
-  ambiguous first argument; put parentheses or a space even after `-' operator"
-- "test/parser/test_quantifiers.rb:96: warning:
-  ambiguous first argument; put parentheses or a space even after `-' operator"
-- "test/parser/test_quantifiers.rb:108: warning:
-  ambiguous first argument; put parentheses or a space even after `-' operator"
-- "test/parser/test_quantifiers.rb:157: warning:
-  ambiguous first argument; put parentheses or a space even after `-' operator"
-- "test/parser/test_quantifiers.rb:169: warning:
-  ambiguous first argument; put parentheses or a space even after `-' operator"
-- "test/parser/test_quantifiers.rb:182: warning:
-  ambiguous first argument; put parentheses or a space even after `-' operator"
-- "test/parser/test_sets.rb:14: warning:
-  ambiguous first argument; put parentheses or a space even after `-' operator"
-- "test/expression/test_base.rb:68: warning:
-  assigned but unused variable - checks"
-- "test/expression/test_conditionals.rb:35:
-  warning: assigned but unused variable - branch_2"
+
+# Unavoidable duplicated character range tests
 - "lib/regexp_parser/expression.rb:132: warning:
   character class has duplicated range: /[[:^xdigit:][:^lower:]]+/"
 - "lib/regexp_parser/expression.rb:132: warning:
   character class has duplicated range: /[a[b[^c]]]/"
-- "lib/regexp_parser/scanner.rb:1647: warning:
-  assigned but unused variable - _nacts"
+
+# Warnings generated only under 1.9.3
 - "lib/regexp_parser/scanner.rb:1647:
   warning: assigned but unused variable - _acts"
-- "test/parser/test_quantifiers.rb:49: warning:
-  ambiguous first argument; put parentheses or even spaces"
-- "test/parser/test_quantifiers.rb:60: warning:
-  ambiguous first argument; put parentheses or even spaces"
-- "test/parser/test_quantifiers.rb:72: warning:
-  ambiguous first argument; put parentheses or even spaces"
-- "test/parser/test_quantifiers.rb:85: warning:
-  ambiguous first argument; put parentheses or even spaces"
-- "test/parser/test_quantifiers.rb:96: warning:
-  ambiguous first argument; put parentheses or even spaces"
-- "test/parser/test_quantifiers.rb:108: warning:
-  ambiguous first argument; put parentheses or even spaces"
-- "test/parser/test_quantifiers.rb:157: warning:
-  ambiguous first argument; put parentheses or even spaces"
-- "test/parser/test_quantifiers.rb:169: warning:
-  ambiguous first argument; put parentheses or even spaces"
-- "test/parser/test_quantifiers.rb:182: warning:
-  ambiguous first argument; put parentheses or even spaces"
-- "test/parser/test_sets.rb:14: warning:
-  ambiguous first argument; put parentheses or even spaces"
+- "lib/regexp_parser/scanner.rb:1647:
+  warning: assigned but unused variable - _nacts"

--- a/test/warnings.yml
+++ b/test/warnings.yml
@@ -1,0 +1,63 @@
+---
+- "lib/regexp_parser/scanner.rb:1646: warning:
+  assigned but unused variable - testEof"
+- "test/scanner/test_escapes.rb:16: warning:
+  Unknown escape \\q is ignored: /c\\qt/"
+- "test/syntax/ruby/test_1.9.3.rb:23: warning:
+  assigned but unused variable - expected"
+- "test/lexer/test_conditionals.rb:34: warning:
+  assigned but unused variable - expected"
+- "test/lexer/test_conditionals.rb:73: warning:
+  assigned but unused variable - expected"
+- "test/parser/test_quantifiers.rb:49: warning:
+  ambiguous first argument; put parentheses or a space even after `-' operator"
+- "test/parser/test_quantifiers.rb:60: warning:
+  ambiguous first argument; put parentheses or a space even after `-' operator"
+- "test/parser/test_quantifiers.rb:72: warning:
+  ambiguous first argument; put parentheses or a space even after `-' operator"
+- "test/parser/test_quantifiers.rb:85: warning:
+  ambiguous first argument; put parentheses or a space even after `-' operator"
+- "test/parser/test_quantifiers.rb:96: warning:
+  ambiguous first argument; put parentheses or a space even after `-' operator"
+- "test/parser/test_quantifiers.rb:108: warning:
+  ambiguous first argument; put parentheses or a space even after `-' operator"
+- "test/parser/test_quantifiers.rb:157: warning:
+  ambiguous first argument; put parentheses or a space even after `-' operator"
+- "test/parser/test_quantifiers.rb:169: warning:
+  ambiguous first argument; put parentheses or a space even after `-' operator"
+- "test/parser/test_quantifiers.rb:182: warning:
+  ambiguous first argument; put parentheses or a space even after `-' operator"
+- "test/parser/test_sets.rb:14: warning:
+  ambiguous first argument; put parentheses or a space even after `-' operator"
+- "test/expression/test_base.rb:68: warning:
+  assigned but unused variable - checks"
+- "test/expression/test_conditionals.rb:35:
+  warning: assigned but unused variable - branch_2"
+- "lib/regexp_parser/expression.rb:132: warning:
+  character class has duplicated range: /[[:^xdigit:][:^lower:]]+/"
+- "lib/regexp_parser/expression.rb:132: warning:
+  character class has duplicated range: /[a[b[^c]]]/"
+- "lib/regexp_parser/scanner.rb:1647: warning:
+  assigned but unused variable - _nacts"
+- "lib/regexp_parser/scanner.rb:1647:
+  warning: assigned but unused variable - _acts"
+- "test/parser/test_quantifiers.rb:49: warning:
+  ambiguous first argument; put parentheses or even spaces"
+- "test/parser/test_quantifiers.rb:60: warning:
+  ambiguous first argument; put parentheses or even spaces"
+- "test/parser/test_quantifiers.rb:72: warning:
+  ambiguous first argument; put parentheses or even spaces"
+- "test/parser/test_quantifiers.rb:85: warning:
+  ambiguous first argument; put parentheses or even spaces"
+- "test/parser/test_quantifiers.rb:96: warning:
+  ambiguous first argument; put parentheses or even spaces"
+- "test/parser/test_quantifiers.rb:108: warning:
+  ambiguous first argument; put parentheses or even spaces"
+- "test/parser/test_quantifiers.rb:157: warning:
+  ambiguous first argument; put parentheses or even spaces"
+- "test/parser/test_quantifiers.rb:169: warning:
+  ambiguous first argument; put parentheses or even spaces"
+- "test/parser/test_quantifiers.rb:182: warning:
+  ambiguous first argument; put parentheses or even spaces"
+- "test/parser/test_sets.rb:14: warning:
+  ambiguous first argument; put parentheses or even spaces"


### PR DESCRIPTION
This PR eliminates all avoidable errors emitted at runtime. It also adds a custom test runner that builds on top of `test/unit`. This runner loads a warning whitelist (`test/warnings.yml`) and asserts that the test suite does not emit any other warnings. 