### PR TITLE
Improve codepoint handling

### DIFF
--- a/lib/regexp_parser/scanner/scanner.rl
+++ b/lib/regexp_parser/scanner/scanner.rl
@@ -53,7 +53,7 @@
   wide_hex_seq_empty    = 'x' . '{' . (space+)? . '}';
 
   codepoint_single      = 'u' . xdigit{4};
-  codepoint_list        = 'u{' . (xdigit{4} . space?)+'}';
+  codepoint_list        = 'u{' . xdigit{1,5} . (space . xdigit{1,5})* . '}';
   codepoint_sequence    = codepoint_single | codepoint_list;
 
   control_sequence      = ('c' | 'C-');

--- a/lib/regexp_parser/syntax/tokens/escape.rb
+++ b/lib/regexp_parser/syntax/tokens/escape.rb
@@ -11,7 +11,7 @@ module Regexp::Syntax
       ASCII = [:bell, :backspace, :escape, :form_feed, :newline, :carriage,
                :space, :tab, :vertical_tab]
 
-      Unicode = [:codepoint_list]
+      Unicode = [:codepoint, :codepoint_list]
 
       Meta  = [:dot, :alternation,
                :zero_or_one, :zero_or_more, :one_or_more,

--- a/test/parser/test_escapes.rb
+++ b/test/parser/test_escapes.rb
@@ -27,6 +27,7 @@ class TestParserEscapes < Test::Unit::TestCase
     /a\}c/    => [1, :escape,   :interval_close,    EscapeSequence::Literal],
 
     # unicode escapes
+    /a\u0640/       => [1, :escape, :codepoint,      EscapeSequence::Literal],
     /a\u{41 1F60D}/ => [1, :escape, :codepoint_list, EscapeSequence::Literal],
 
      # hex escapes

--- a/test/parser/test_escapes.rb
+++ b/test/parser/test_escapes.rb
@@ -27,7 +27,7 @@ class TestParserEscapes < Test::Unit::TestCase
     /a\}c/    => [1, :escape,   :interval_close,    EscapeSequence::Literal],
 
     # unicode escapes
-    /a\u{9879}/ => [1, :escape, :codepoint_list,    EscapeSequence::Literal],
+    /a\u{41 1F60D}/ => [1, :escape, :codepoint_list, EscapeSequence::Literal],
 
      # hex escapes
     /a\xFF/n =>  [1, :escape, :hex,                 EscapeSequence::Literal],

--- a/test/scanner/test_escapes.rb
+++ b/test/scanner/test_escapes.rb
@@ -25,7 +25,7 @@ class ScannerEscapes < Test::Unit::TestCase
     'a\x{0640}c'      => [1, :escape,  :hex_wide,         '\x{0640}',       1,  9],
 
     'a\u0640c'        => [1, :escape,  :codepoint,        '\u0640',         1,  7],
-    'a\u{0640 0641}c' => [1, :escape,  :codepoint_list,   '\u{0640 0641}',  1,  14],
+    'a\u{640 0641}c'  => [1, :escape,  :codepoint_list,   '\u{640 0641}',   1,  13],
 
     /a\cBc/           => [1, :escape,  :control,          '\cB',            1,  4],
     /a\C-bc/          => [1, :escape,  :control,          '\C-b',           1,  5],

--- a/test/warnings.yml
+++ b/test/warnings.yml
@@ -1,6 +1,6 @@
 ---
 # Unused variable emitted by ragel
-- "lib/regexp_parser/scanner.rb:1646: warning:
+- "lib/regexp_parser/scanner.rb:1674: warning:
   assigned but unused variable - testEof"
 
 # Unavoidable duplicated character range tests

--- a/test/warnings.yml
+++ b/test/warnings.yml
@@ -10,7 +10,7 @@
   character class has duplicated range: /[a[b[^c]]]/"
 
 # Warnings generated only under 1.9.3
-- "lib/regexp_parser/scanner.rb:1647:
+- "lib/regexp_parser/scanner.rb:1675:
   warning: assigned but unused variable - _acts"
-- "lib/regexp_parser/scanner.rb:1647:
+- "lib/regexp_parser/scanner.rb:1675:
   warning: assigned but unused variable - _nacts"


### PR DESCRIPTION
Hi,

I’ve made a small gem based on regexp_parser. It’s called [js_regex](https://github.com/janosch-x/js_regex). Nothing special, but it might cause most of regexp_parser’s usage now, as it has turned into a dependency of the fairly popular [client_side_validations](https://github.com/DavyJonesLocker/client_side_validations) gem.

Either way, I have found a few minor things and will open some PRs or issues for them these days.

Here is the first:

Regexp::Scanner won’t accept wide codepoints (or "codepoint lists", which I’ve never seen used as such) with a length other than 4.

E.g.:

```ruby
/\u{41}/ =~ 'A' # => 0
Regexp::Scanner.scan(/\u{41}/) # => Regexp::Scanner::ScannerError: Scan error at '\u{41}'
```

The most common use case for this might be scanning for astral plane chars (?).

```ruby
/[\u{10000}-\u{FFFFF}]/ =~ '😍' # => 0
```

That’s what the first commit in this PR is for.

The second commit addresses this issue:

```
Regexp::Parser.parse(/\u1234/) # => Regexp::Syntax::NotImplementedError: Regexp::Syntax::Ruby::V233 does not implement: [escape:codepoint]
```