### PR TITLE
Make property scanning in sets consistent

### DIFF
--- a/lib/regexp_parser/scanner/property.rl
+++ b/lib/regexp_parser/scanner/property.rl
@@ -63,13 +63,12 @@
       if in_set
         type = :set
       else
-        type = text[1,1] == 'p' ? :property : :nonproperty
+        type = (text[1] == 'P') ^ (text[3] == '^') ? :nonproperty : :property
       end
 
       name = data[ts+2..te-2].pack('c*').gsub(/[\s_]/,'').downcase
       if name[0].chr == '^'
         name = name[1..-1]
-        type = :nonproperty
       end
 
       case name

--- a/test/parser/test_properties.rb
+++ b/test/parser/test_properties.rb
@@ -318,6 +318,18 @@ class ParserProperties < Test::Unit::TestCase
     assert_equal true, t.expressions[1].negative?
   end
 
+  def test_parse_caret_nonproperty_negative
+    t = RP.parse 'ab\p{^L}cd', 'ruby/1.9'
+
+    assert_equal true, t.expressions[1].negative?
+  end
+
+  def test_parse_double_negated_property_negative
+    t = RP.parse 'ab\P{^L}cd', 'ruby/1.9'
+
+    assert_equal false, t.expressions[1].negative?
+  end
+
   def test_parse_property_age
     t = RP.parse 'ab\p{age=5.2}cd', 'ruby/1.9'
 

--- a/test/scanner/test_properties.rb
+++ b/test/scanner/test_properties.rb
@@ -317,5 +317,13 @@ class ScannerProperties < Test::Unit::TestCase
       assert_equal :nonproperty, result[0]
       assert_equal token,        result[1]
     end
+
+    define_method "test_scan_double_negated_property_#{token}_#{count}" do
+      tokens = RS.scan("a\\P{^#{property}}c")
+      result = tokens.at(1)
+
+      assert_equal :property, result[0]
+      assert_equal token,     result[1]
+    end
   end
 end

--- a/test/scanner/test_sets.rb
+++ b/test/scanner/test_sets.rb
@@ -58,6 +58,8 @@ class ScannerSets < Test::Unit::TestCase
 
     '[a\p{digit}c]'         => [2, :set,    :digit,           '\p{digit}',  2, 11],
     '[a\P{digit}c]'         => [2, :set,    :digit,           '\P{digit}',  2, 11],
+    '[a\p{^digit}c]'        => [2, :set,    :digit,           '\p{^digit}', 2, 12],
+    '[a\P{^digit}c]'        => [2, :set,    :digit,           '\P{^digit}', 2, 12],
 
     '[a\p{ALPHA}c]'         => [2, :set,    :alpha,           '\p{ALPHA}',  2, 11],
     '[a\p{P}c]'             => [2, :set,    :punct_any,       '\p{P}',      2, 7],


### PR DESCRIPTION
See issue #28.

The `in_set` global is actually set correctly [here](https://github.com/ammar/regexp_parser/blob/2e9cda515a4f03952d7f444407d617d747bb3c5e/lib/regexp_parser/scanner/property.rl#L63), but for nonproperties with a caret, the `:set` type is then overridden [here](https://github.com/ammar/regexp_parser/blob/2e9cda515a4f03952d7f444407d617d747bb3c5e/lib/regexp_parser/scanner/property.rl#L70-L72).

This PR fixes this.

As a bonus, it correctly detects `\P{^foo}` as a positive `:property`, although probably no one in his right mind would write that 😁 