### PR TITLE
Fix NotImplementedError for 'member_hex' tokens

### DIFF
--- a/lib/regexp_parser/syntax/tokens/character_set.rb
+++ b/lib/regexp_parser/syntax/tokens/character_set.rb
@@ -5,7 +5,8 @@ module Regexp::Syntax
       OpenClose = [:open, :close]
 
       Basic     = [:negate, :member, :range]
-      Extended  = Basic + [:escape, :intersection, :range_hex, :backspace]
+      Extended  = Basic + [:escape, :intersection, :backspace,
+                           :member_hex, :range_hex]
 
       Types     = [:type_digit, :type_nondigit, :type_hex, :type_nonhex,
                    :type_space, :type_nonspace, :type_word, :type_nonword]

--- a/test/parser/test_sets.rb
+++ b/test/parser/test_sets.rb
@@ -39,6 +39,16 @@ class TestParserSets < Test::Unit::TestCase
     assert_equal false, exp.include?(']')
   end
 
+  def test_parse_hex_members
+    root = RP.parse('[\x20\x24-\x26\x28]', :any)
+    exp  = root.expressions.at(0)
+
+    assert_equal true,  exp.include?('\x20')
+    assert_equal true,  exp.include?('\x24-\x26')
+    assert_equal true,  exp.include?('\x28')
+    assert_equal false, exp.include?(']')
+  end
+
   def test_parse_chat_type_set_members
     root = RP.parse('[\da-z]', :any)
     exp  = root.expressions.at(0)

--- a/test/scanner/test_sets.rb
+++ b/test/scanner/test_sets.rb
@@ -20,6 +20,8 @@ class ScannerSets < Test::Unit::TestCase
     '[<]'                   => [1, :set,    :member,          '<',          1, 2],
     '[>]'                   => [1, :set,    :member,          '>',          1, 2],
 
+    '[\x20]'                => [1, :set,    :member_hex,      '\x20',       1, 5],
+
     '[\.]'                  => [1, :set,    :escape,          '\.',         1, 3],
     '[\!]'                  => [1, :set,    :escape,          '\!',         1, 3],
     '[\#]'                  => [1, :set,    :escape,          '\#',         1, 3],


### PR DESCRIPTION
```ruby
Regexp::Parser.parse(/[\x20-\x28]/)
# => <... @expressions=[#<Regexp::Expression::CharacterSet @members=["\\x41-\\x42"] ...>

Regexp::Parser.parse(/[\x20]/)
# => Regexp::Syntax::NotImplementedError: Regexp::Syntax::Ruby::V241 does not implement: [set:member_hex]
```