### PR TITLE
Fix NotImplementedError for octal escapes

### DIFF
--- a/lib/regexp_parser/syntax/ruby/1.9.1.rb
+++ b/lib/regexp_parser/syntax/ruby/1.9.1.rb
@@ -15,7 +15,7 @@ module Regexp::Syntax
         implements :backref, Backreference::All +
           SubexpressionCall::All
 
-        implements :escape, Escape::Unicode + Escape::Hex
+        implements :escape, Escape::Unicode + Escape::Hex + Escape::Octal
 
         implements :type, CharacterType::Hex
 

--- a/lib/regexp_parser/syntax/tokens/escape.rb
+++ b/lib/regexp_parser/syntax/tokens/escape.rb
@@ -23,6 +23,8 @@ module Regexp::Syntax
 
       Hex   = [:hex]
 
+      Octal = [:octal]
+
       All   = Basic + Backreference + ASCII + Meta
       Type  = :escape
     end

--- a/test/parser/test_escapes.rb
+++ b/test/parser/test_escapes.rb
@@ -32,6 +32,9 @@ class TestParserEscapes < Test::Unit::TestCase
 
      # hex escapes
     /a\xFF/n =>  [1, :escape, :hex,                 EscapeSequence::Literal],
+
+    # octal escapes
+    /a\177/n =>  [1, :escape, :octal,               EscapeSequence::Literal],
   }
 
   tests.each_with_index do |(pattern, (index, type, token, klass)), count|

--- a/test/syntax/ruby/test_1.9.1.rb
+++ b/test/syntax/ruby/test_1.9.1.rb
@@ -10,7 +10,8 @@ class TestSyntaxRuby_V191 < Test::Unit::TestCase
   tests = {
     :implements => {
       :escape => [
-        Escape::Backreference + Escape::ASCII + Escape::Meta + Escape::Unicode
+        Escape::Backreference + Escape::ASCII + Escape::Meta + Escape::Unicode +
+        Escape::Hex + Escape::Octal
       ].flatten,
 
       :type => [


### PR DESCRIPTION
This fixes the following:

```ruby
Regexp::Parser.parse(/a\177b/)
# => Regexp::Syntax::NotImplementedError: Regexp::Syntax::Ruby::V241 does not implement: [escape:octal]
```

In truth, the `octal` escape is available since at least Ruby 1.8.6, but this is also true for the `hex` escape and possibly more token types in the 1.9.1 syntax file, and I didn't want to mess with that. 