### PR TITLE
Add support for linebreak and extended grapheme types ("\R" and "\X")

### DIFF
--- a/lib/regexp_parser/expression/classes/type.rb
+++ b/lib/regexp_parser/expression/classes/type.rb
@@ -3,15 +3,17 @@ module Regexp::Expression
   module CharacterType
     class Base < Regexp::Expression::Base; end
 
-    class Any         < CharacterType::Base; end
-    class Digit       < CharacterType::Base; end
-    class NonDigit    < CharacterType::Base; end
-    class Hex         < CharacterType::Base; end
-    class NonHex      < CharacterType::Base; end
-    class Word        < CharacterType::Base; end
-    class NonWord     < CharacterType::Base; end
-    class Space       < CharacterType::Base; end
-    class NonSpace    < CharacterType::Base; end
+    class Any              < CharacterType::Base; end
+    class Digit            < CharacterType::Base; end
+    class NonDigit         < CharacterType::Base; end
+    class Hex              < CharacterType::Base; end
+    class NonHex           < CharacterType::Base; end
+    class Word             < CharacterType::Base; end
+    class NonWord          < CharacterType::Base; end
+    class Space            < CharacterType::Base; end
+    class NonSpace         < CharacterType::Base; end
+    class Linebreak        < CharacterType::Base; end
+    class ExtendedGrapheme < CharacterType::Base; end
   end
 
 end

--- a/lib/regexp_parser/parser.rb
+++ b/lib/regexp_parser/parser.rb
@@ -167,6 +167,10 @@ module Regexp::Parser
       @node << CharacterType::Word.new(token)
     when :nonword
       @node << CharacterType::NonWord.new(token)
+    when :linebreak
+      @node << CharacterType::Linebreak.new(token)
+    when :xgrapheme
+      @node << CharacterType::ExtendedGrapheme.new(token)
     else
       raise UnknownTokenError.new('CharacterType', token)
     end

--- a/lib/regexp_parser/scanner/scanner.rl
+++ b/lib/regexp_parser/scanner/scanner.rl
@@ -35,7 +35,7 @@
   collating_sequence    = '[.' . (alpha | [\-])+ . '.]';
   character_equivalent  = '[=' . alpha . '=]';
 
-  char_type             = [dDhHsSwW];
+  char_type             = [dDhHsSwWRX];
 
   line_anchor           = beginning_of_line | end_of_line;
   anchor_char           = [AbBzZG];
@@ -258,6 +258,8 @@
       when '\S'; emit(set_type, :type_nonspace,  text, ts-1, te)
       when '\w'; emit(set_type, :type_word,      text, ts-1, te)
       when '\W'; emit(set_type, :type_nonword,   text, ts-1, te)
+      when '\R'; emit(set_type, :type_linebreak, text, ts-1, te)
+      when '\X'; emit(set_type, :type_xgrapheme, text, ts-1, te)
       end
       fret;
     };
@@ -497,6 +499,8 @@
       when '\\S'; emit(:type, :nonspace,   text, ts, te)
       when '\\w'; emit(:type, :word,       text, ts, te)
       when '\\W'; emit(:type, :nonword,    text, ts, te)
+      when '\\R'; emit(:type, :linebreak,  text, ts, te)
+      when '\\X'; emit(:type, :xgrapheme,  text, ts, te)
       else
         raise ScannerError.new(
           "Unexpected character in type at #{text} (char #{ts})")

--- a/lib/regexp_parser/syntax/ruby/2.0.0.rb
+++ b/lib/regexp_parser/syntax/ruby/2.0.0.rb
@@ -12,6 +12,10 @@ module Regexp::Syntax
         implements :conditional, Conditional::All
         implements :property,    UnicodeProperty::V200
         implements :nonproperty, UnicodeProperty::V200
+
+        implements :type,        CharacterType::Clustered
+        implements :set,         CharacterSet::Clustered
+        implements :subset,      CharacterSet::Clustered
       end
     end
 

--- a/lib/regexp_parser/syntax/tokens/character_set.rb
+++ b/lib/regexp_parser/syntax/tokens/character_set.rb
@@ -10,6 +10,8 @@ module Regexp::Syntax
       Types     = [:type_digit, :type_nondigit, :type_hex, :type_nonhex,
                    :type_space, :type_nonspace, :type_word, :type_nonword]
 
+      Clustered = [:type_linebreak, :type_xgrapheme]
+
       module POSIX
         Standard  = [
           :class_alnum, :class_alpha, :class_blank, :class_cntrl,
@@ -30,7 +32,7 @@ module Regexp::Syntax
         All = Standard + StandardNegative + Extensions + ExtensionsNegative
       end
 
-      All = Basic + Extended + Types + POSIX::All
+      All = Basic + Extended + Types + Clustered + POSIX::All
       Type = :set
 
       module SubSet

--- a/lib/regexp_parser/syntax/tokens/character_type.rb
+++ b/lib/regexp_parser/syntax/tokens/character_type.rb
@@ -6,7 +6,9 @@ module Regexp::Syntax
       Extended  = [:digit, :nondigit, :space, :nonspace, :word, :nonword]
       Hex       = [:hex, :nonhex]
 
-      All = Basic + Extended + Hex
+      Clustered = [:linebreak, :xgrapheme]
+
+      All = Basic + Extended + Hex + Clustered
       Type = :type
     end
 

--- a/test/parser/test_types.rb
+++ b/test/parser/test_types.rb
@@ -29,4 +29,22 @@ class TestParserTypes < Test::Unit::TestCase
     end
   end
 
+  tests_2_0 = {
+    'a\Rc'    => [1, :type,   :linebreak, CharacterType::Linebreak],
+    'a\Xc'    => [1, :type,   :xgrapheme, CharacterType::ExtendedGrapheme],
+  }
+
+  tests_2_0.each_with_index do |(pattern, (index, type, token, klass)), count|
+    define_method "test_parse_type_#{token}_#{count}" do
+      root = RP.parse(pattern, 'ruby/2.0')
+      exp  = root.expressions.at(index)
+
+      assert exp.is_a?( klass ),
+             "Expected #{klass}, but got #{exp.class.name}"
+
+      assert_equal type,  exp.type
+      assert_equal token, exp.token
+    end
+  end
+
 end

--- a/test/scanner/test_sets.rb
+++ b/test/scanner/test_sets.rb
@@ -40,6 +40,9 @@ class ScannerSets < Test::Unit::TestCase
     '[\w]'                  => [1, :set,    :type_word,       '\w',         1, 3],
     '[\W]'                  => [1, :set,    :type_nonword,    '\W',         1, 3],
 
+    '[\R]'                  => [1, :set,    :type_linebreak,  '\R',         1, 3],
+    '[\X]'                  => [1, :set,    :type_xgrapheme,  '\X',         1, 3],
+
     '[a-c]'                 => [1, :set,    :range,           'a-c',        1, 4],
     '[a-c-]'                => [2, :set,    :member,          '-',          4, 6],
     '[a-c^]'                => [2, :set,    :member,          '^',          4, 5],

--- a/test/scanner/test_types.rb
+++ b/test/scanner/test_types.rb
@@ -14,6 +14,9 @@ class ScannerTypes < Test::Unit::TestCase
 
    'a\wc' => [1, :type,  :word,        '\w',  1, 3],
    'a\Wc' => [1, :type,  :nonword,     '\W',  1, 3],
+
+   'a\Rc' => [1, :type,  :linebreak,   '\R',  1, 3],
+   'a\Xc' => [1, :type,  :xgrapheme,   '\X',  1, 3],
   }
 
   tests.each do |(pattern, (index, type, token, text, ts, te))|


### PR DESCRIPTION
`\R` seems to be useful mainly to deal with the occasional Windows linebreak:

```ruby
"___\r\n___\n___".gsub(/\R/, 'x') # => "___x___x___"
```

`\X` is for [extended graphemes](http://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries), e.g. latin letters with combined diacritical marks:

```ruby
'g̈'.scan(/./) # => ["g", "̈"]
'g̈'.scan(/\X/) # => ["g̈"]
```

They were added with Onigmo. Relevant documentation is [here](https://github.com/k-takata/Onigmo/blob/fc16bafc139016a7d5d8098efadcd97e749d3523/doc/RE#L109-L124).