### PR TITLE
Add support for more metacontrol notations

### DIFF
--- a/lib/regexp_parser/parser.rb
+++ b/lib/regexp_parser/parser.rb
@@ -325,10 +325,14 @@ module Regexp::Parser
       @node << EscapeSequence::VerticalTab.new(token)
 
     when :control
-      @node << EscapeSequence::Control.new(token)
+      if token.text =~ /\A(?:\\C-\\M|\\c\\M)/
+        @node << EscapeSequence::MetaControl.new(token)
+      else
+        @node << EscapeSequence::Control.new(token)
+      end
 
     when :meta_sequence
-      if token.text =~ /\A\\M-\\C/
+      if token.text =~ /\A\\M-\\[Cc]/
         @node << EscapeSequence::MetaControl.new(token)
       else
         @node << EscapeSequence::Meta.new(token)

--- a/lib/regexp_parser/scanner/scanner.rl
+++ b/lib/regexp_parser/scanner/scanner.rl
@@ -56,7 +56,7 @@
   codepoint_list        = 'u{' . xdigit{1,5} . (space . xdigit{1,5})* . '}';
   codepoint_sequence    = codepoint_single | codepoint_list;
 
-  control_sequence      = ('c' | 'C-');
+  control_sequence      = ('c' | 'C-') . (backslash . 'M-')?;
 
   meta_sequence         = 'M-' . (backslash . control_sequence)?;
 

--- a/test/parser/test_escapes.rb
+++ b/test/parser/test_escapes.rb
@@ -75,4 +75,25 @@ class TestParserEscapes < Test::Unit::TestCase
     assert_equal '\\M-\\C-X',                 root[2].text
   end
 
+  def test_parse_lower_c_meta_control_sequence
+    root = RP.parse(/\A\\\M-\cX/n)
+
+    assert_equal EscapeSequence::MetaControl, root[2].class
+    assert_equal '\\M-\\cX',                  root[2].text
+  end
+
+  def test_parse_escape_reverse_meta_control_sequence
+    root = RP.parse(/\A\\\C-\M-X/n)
+
+    assert_equal EscapeSequence::MetaControl, root[2].class
+    assert_equal '\\C-\\M-X',                 root[2].text
+  end
+
+  def test_parse_escape_reverse_lower_c_meta_control_sequence
+    root = RP.parse(/\A\\\c\M-X/n)
+
+    assert_equal EscapeSequence::MetaControl, root[2].class
+    assert_equal '\\c\\M-X',                  root[2].text
+  end
+
 end

--- a/test/scanner/test_errors.rb
+++ b/test/scanner/test_errors.rb
@@ -72,14 +72,19 @@ class ScannerErrors < Test::Unit::TestCase
 
   def test_scanner_eof_in_control_sequence
     assert_raise( RS::PrematureEndError ) { RS.scan('\c') }
+    assert_raise( RS::PrematureEndError ) { RS.scan('\c\M') }
+    assert_raise( RS::PrematureEndError ) { RS.scan('\c\M-') }
     assert_raise( RS::PrematureEndError ) { RS.scan('\C') }
     assert_raise( RS::PrematureEndError ) { RS.scan('\C-') }
+    assert_raise( RS::PrematureEndError ) { RS.scan('\C-\M') }
+    assert_raise( RS::PrematureEndError ) { RS.scan('\C-\M-') }
   end
 
   def test_scanner_eof_in_meta_sequence
     assert_raise( RS::PrematureEndError ) { RS.scan('\M') }
     assert_raise( RS::PrematureEndError ) { RS.scan('\M-') }
     assert_raise( RS::PrematureEndError ) { RS.scan('\M-\\') }
+    assert_raise( RS::PrematureEndError ) { RS.scan('\M-\c') }
     assert_raise( RS::PrematureEndError ) { RS.scan('\M-\C') }
     assert_raise( RS::PrematureEndError ) { RS.scan('\M-\C-') }
   end

--- a/test/scanner/test_escapes.rb
+++ b/test/scanner/test_escapes.rb
@@ -29,9 +29,12 @@ class ScannerEscapes < Test::Unit::TestCase
 
     /a\cBc/           => [1, :escape,  :control,          '\cB',            1,  4],
     /a\C-bc/          => [1, :escape,  :control,          '\C-b',           1,  5],
+    /a\c\M-Bc/n       => [1, :escape,  :control,          '\c\M-B',         1,  7],
+    /a\C-\M-Bc/n      => [1, :escape,  :control,          '\C-\M-B',        1,  8],
 
     /a\M-Bc/n         => [1, :escape,  :meta_sequence,    '\M-B',           1,  5],
     /a\M-\C-Bc/n      => [1, :escape,  :meta_sequence,    '\M-\C-B',        1,  8],
+    /a\M-\cBc/n       => [1, :escape,  :meta_sequence,    '\M-\cB',         1,  7],
 
     'ab\\\xcd'        => [1, :escape,  :backslash,        '\\\\',           2,  4],
     'ab\\\0cd'        => [1, :escape,  :backslash,        '\\\\',           2,  4],

--- a/test/warnings.yml
+++ b/test/warnings.yml
@@ -1,6 +1,6 @@
 ---
 # Unused variable emitted by ragel
-- "lib/regexp_parser/scanner.rb:1674: warning:
+- "lib/regexp_parser/scanner.rb:1688: warning:
   assigned but unused variable - testEof"
 
 # Unavoidable duplicated character range tests
@@ -10,7 +10,7 @@
   character class has duplicated range: /[a[b[^c]]]/"
 
 # Warnings generated only under 1.9.3
-- "lib/regexp_parser/scanner.rb:1675:
+- "lib/regexp_parser/scanner.rb:1689:
   warning: assigned but unused variable - _acts"
-- "lib/regexp_parser/scanner.rb:1675:
+- "lib/regexp_parser/scanner.rb:1689:
   warning: assigned but unused variable - _nacts"


### PR DESCRIPTION
So far, regexp_parser only supports this style:

```ruby
"\M-\C-A" # => "\x81"
```

Ruby provides these other styles as well:

```ruby
"\M-\cA"  # => "\x81"
"\C-\M-A" # => "\x81"
"\c\M-A"  # => "\x81"
```

These are currently scanned and/or parsed incorrectly, e.g.:

```ruby
Regexp::Parser.parse(/\C-\M-A/n).expressions
# => [
#  #<Regexp::Expression::EscapeSequence::Control ... @text="\\C-\\" ...>,
#  #<Regexp::Expression::Literal ... @text="M-A" >
# ]
```