### PR TITLE
Eliminate "warning: assigned but unused variable - testEof"

### DIFF
--- a/lib/regexp_parser/scanner/scanner.rl
+++ b/lib/regexp_parser/scanner/scanner.rl
@@ -808,6 +808,9 @@ class Regexp::Scanner
     %% write init;
     %% write exec;
 
+    # to avoid "warning: assigned but unused variable - testEof"
+    testEof = testEof
+
     if cs == re_scanner_error
       text = ts ? copy(data, ts-1..-1) : data.pack('c*')
       raise ScannerError.new("Scan error at '#{text}'")

--- a/test/warnings.yml
+++ b/test/warnings.yml
@@ -1,7 +1,4 @@
 ---
-# Unused variable emitted by ragel
-- "assigned but unused variable - testEof"
-
 # Unavoidable warnings in character range tests
 - "character class has duplicated range"
 - "character class has '-' without escape"


### PR DESCRIPTION
Current version of this gem emits a Ruby warning even only when being required:

```sh
% ruby -rregexp_parser -wep
.../gems/regexp_parser-1.2.0/lib/regexp_parser/scanner.rb:1146: warning: assigned but unused variable - testEof
```

Now we're seeing this error everyday, in my case probably because capybara is depending on this gem.

I know this patch is a dirty solution, but this eliminates the warning anyway.