### PR TITLE
Make traverse/each_expression to return an Enumerator if they're called without a block

### DIFF
--- a/lib/regexp_parser/expression/methods/match_length.rb
+++ b/lib/regexp_parser/expression/methods/match_length.rb
@@ -22,7 +22,7 @@ class Regexp::MatchLength
   end
 
   def each(opts = {})
-    return enum_for(__method__) unless block_given?
+    return enum_for(__method__, opts) unless block_given?
     limit = opts[:limit] || 1000
     yielded = 0
     (min..max).each do |num|

--- a/lib/regexp_parser/expression/methods/traverse.rb
+++ b/lib/regexp_parser/expression/methods/traverse.rb
@@ -14,7 +14,7 @@ module Regexp::Expression
     #
     # Returns self.
     def traverse(include_self = false, &block)
-      raise 'traverse requires a block' unless block_given?
+      return enum_for(__method__, include_self) unless block_given?
 
       block.call(:enter, self, 0) if include_self
 
@@ -37,6 +37,8 @@ module Regexp::Expression
     # Iterates over the expressions of this expression as an array, passing
     # the expression and its index within its parent to the given block.
     def each_expression(include_self = false, &block)
+      return enum_for(__method__, include_self) unless block_given?
+
       traverse(include_self) do |event, exp, index|
         yield(exp, index) unless event == :exit
       end

--- a/spec/expression/methods/match_length_spec.rb
+++ b/spec/expression/methods/match_length_spec.rb
@@ -120,6 +120,13 @@ RSpec.describe(Regexp::MatchLength) do
       expect { result.next }.to raise_error(StopIteration)
     end
 
+    it 'is aware of limit option even if called without a block' do
+      result = ML.of(/a?/).each(limit: 1)
+      expect(result).to be_a(Enumerator)
+      expect(result.next).to eq 0
+      expect { result.next }.to raise_error(StopIteration)
+    end
+
     it 'is limited to 1000 iterations in case there are infinite match lengths' do
       expect(ML.of(/a*/).first(3000).size).to eq 1000
     end

--- a/spec/expression/methods/traverse_spec.rb
+++ b/spec/expression/methods/traverse_spec.rb
@@ -39,6 +39,17 @@ RSpec.describe('Subexpression#traverse') do
     expect(visits).to eq 9
   end
 
+  specify('Subexpression#traverse without a block') do
+    root = RP.parse(/abc/)
+    enum = root.traverse
+
+    expect(enum).to be_a(Enumerator)
+    event, expr, idx = enum.next
+    expect(event).to eq(:visit)
+    expect(expr).to be_a(Regexp::Expression::Literal)
+    expect(idx).to eq(0)
+  end
+
   specify('Subexpression#walk alias') do
     root = RP.parse(/abc/)
 
@@ -79,6 +90,16 @@ RSpec.describe('Subexpression#traverse') do
     root.each_expression(true) { |_exp, index| (indices << index) }
 
     expect(indices).to eq [0, 0, 1, 0, 2]
+  end
+
+  specify('Subexpression#each_expression without a block') do
+    root = RP.parse(/abc/)
+    enum = root.each_expression
+
+    expect(enum).to be_a(Enumerator)
+    expr, idx = enum.next
+    expect(expr).to be_a(Regexp::Expression::Literal)
+    expect(idx).to eq(0)
   end
 
   specify('Subexpression#flat_map without block') do


### PR DESCRIPTION
# Problem


Currently, `Subexpression#traverse` and `Subexpression#each_expression` require a block. 
So It is difficult to combine other Enumerator methods, such as `map`, `select` and so on.

```ruby
require 'regexp_parser'

root = Regexp::Parser.parse(/foo|bar/)

# To get all literal nodes

# It works, but not smart
result = []
root.each_expression do |expr|
  result << expr if expr.is_a?(Regexp::Expression::Literal)
end
p result

# I'd like to write the following, but it doesn't works well without this pull request.
result = root.each_expression.select do |expr, _idx|
  expr.is_a?(Regexp::Expression::Literal)
end
p result
```


And, in the real world, I'd like to use it for RuboCop.
https://github.com/pocke/rubocop-regular_expression/blob/b3f243b01973705cf43e8a3594c0854729e1ab7d/lib/rubocop/cop/regular_expression/mixed_capture_types.rb#L31-L41


# Solution


Make them accept calling without a block.




# Note


I found a bug of `MatchLength#each` method. It wasn't aware of `opts` argument if the method is called without a block. So this pull request also fixes the problem.