### PR TITLE
Support informal delimiter literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,8 @@ Regexp::Scanner.scan( /(cat?([bhm]at)){3,5}/ ).map {|token| token[2]}
     to the lexer.
 
   * The MRI implementation may accept expressions that either conflict with
-    the documentation or are undocumented. The scanner does not support such
-    implementation quirks.
-    _(See issues [#3](https://github.com/ammar/regexp_parser/issues/3) and
-    [#15](https://github.com/ammar/regexp_parser/issues/15) for examples)_
-
+    the documentation or are undocumented, like `{}` and `]` _(unescaped)_.
+    The scanner will try to support as many of these cases as possible.
 
 ---
 ### Syntax

--- a/lib/regexp_parser/scanner/scanner.rl
+++ b/lib/regexp_parser/scanner/scanner.rl
@@ -62,18 +62,16 @@
   quantifier_possessive = '?+' | '*+' | '++';
   quantifier_mode       = '?'  | '+';
 
-  quantifier_exact      = range_open . (digit+) . range_close . quantifier_mode?;
-  quantifier_minimum    = range_open . (digit+) . ',' . range_close . quantifier_mode?;
-  quantifier_maximum    = range_open . ',' . (digit+) . range_close . quantifier_mode?;
-  quantifier_range      = range_open . (digit+) . ',' . (digit+) .
-                          range_close . quantifier_mode?;
-
-  quantifier_interval   = quantifier_exact | quantifier_minimum |
-                          quantifier_maximum | quantifier_range;
+  quantity_exact        = (digit+);
+  quantity_minimum      = (digit+) . ',';
+  quantity_maximum      = ',' . (digit+);
+  quantity_range        = (digit+) . ',' . (digit+);
+  quantifier_interval   = range_open . ( quantity_exact | quantity_minimum |
+                          quantity_maximum | quantity_range ) . range_close .
+                          quantifier_mode?;
 
   quantifiers           = quantifier_greedy | quantifier_reluctant |
                           quantifier_possessive | quantifier_interval;
-
 
   conditional           = '(?(';
 
@@ -120,7 +118,7 @@
                           curlies | parantheses | brackets |
                           line_anchor | quantifier_greedy;
 
-  literal_delimiters    = ']' | '}' | '{}';
+  literal_delimiters    = ']' | '}';
 
   ascii_print           = ((0x20..0x7e) - meta_char);
   ascii_nonprint        = (0x01..0x1f | 0x7f);

--- a/spec/lexer/delimiters_spec.rb
+++ b/spec/lexer/delimiters_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+RSpec.describe('Literal delimiter lexing') do
+  include_examples 'lex', '}',
+    0 => [:literal,     :literal,       '}',       0,  1,  0, 0, 0]
+
+  include_examples 'lex', '}}',
+    0 => [:literal,     :literal,       '}}',      0,  2,  0, 0, 0]
+
+  include_examples 'lex', '{',
+    0 => [:literal,     :literal,       '{',       0,  1,  0, 0, 0]
+
+  include_examples 'lex', '{{',
+    0 => [:literal,     :literal,       '{{',      0,  2,  0, 0, 0]
+
+  include_examples 'lex', '{}',
+    0 => [:literal,     :literal,       '{}',      0,  2,  0, 0, 0]
+
+  include_examples 'lex', '}{',
+    0 => [:literal,     :literal,       '}{',      0,  2,  0, 0, 0]
+
+  include_examples 'lex', '}{+',
+    0 => [:literal,     :literal,       '}',       0,  1,  0, 0, 0],
+    1 => [:literal,     :literal,       '{',       1,  2,  0, 0, 0],
+    2 => [:quantifier,  :one_or_more,   '+',       2,  3,  0, 0, 0]
+
+  include_examples 'lex', '{{var}}',
+    0 => [:literal,     :literal,       '{{var}}',  0,  7,  0, 0, 0]
+
+  include_examples 'lex', 'a{b}c',
+    0 => [:literal,     :literal,       'a{b}c',    0,  5,  0, 0, 0]
+
+  include_examples 'lex', '({.+})',
+    0 => [:group,       :capture,       '(',    0,  1,  0, 0, 0],
+    1 => [:literal,     :literal,       '{',    1,  2,  1, 0, 0],
+    2 => [:meta,        :dot,           '.',    2,  3,  1, 0, 0],
+    3 => [:quantifier,  :one_or_more,   '+',    3,  4,  1, 0, 0],
+    4 => [:literal,     :literal,       '}',    4,  5,  1, 0, 0],
+    5 => [:group,       :close,         ')',    5,  6,  0, 0, 0]
+
+  include_examples 'lex', ']',
+    0 => [:literal,     :literal,       ']',        0,  1,  0, 0, 0]
+
+  include_examples 'lex', ']]',
+    0 => [:literal,     :literal,       ']]',       0,  2,  0, 0, 0]
+
+  include_examples 'lex', ']\[',
+    0 => [:literal,     :literal,       ']',        0,  1,  0, 0, 0],
+    1 => [:escape,      :set_open,      '\[',       1,  3,  0, 0, 0]
+
+  include_examples 'lex', '()',
+    0 => [:group,       :capture,       '(',        0,  1,  0, 0, 0],
+    1 => [:group,       :close,         ')',        1,  2,  0, 0, 0]
+
+  include_examples 'lex', '{abc:.+}}}[^}]]}',
+    0 => [:literal,     :literal,       '{abc:',    0,  5,  0, 0, 0],
+    1 => [:meta,        :dot,           '.',        5,  6,  0, 0, 0],
+    2 => [:quantifier,  :one_or_more,   '+',        6,  7,  0, 0, 0],
+    3 => [:literal,     :literal,       '}}}',      7,  10, 0, 0, 0],
+    4 => [:set,         :open,          '[',        10, 11, 0, 0, 0],
+    5 => [:set,         :negate,        '^',        11, 12, 0, 1, 0],
+    6 => [:literal,     :literal,       '}',        12, 13, 0, 1, 0],
+    7 => [:set,         :close,         ']',        13, 14, 0, 0, 0],
+    8 => [:literal,     :literal,       ']}',       14, 16, 0, 0, 0]
+end

--- a/spec/lexer/delimiters_spec.rb
+++ b/spec/lexer/delimiters_spec.rb
@@ -30,6 +30,9 @@ RSpec.describe('Literal delimiter lexing') do
   include_examples 'lex', 'a{b}c',
     0 => [:literal,     :literal,       'a{b}c',    0,  5,  0, 0, 0]
 
+  include_examples 'lex', 'a{1,2',
+    0 => [:literal,     :literal,       'a{1,2',    0,  5,  0, 0, 0]
+
   include_examples 'lex', '({.+})',
     0 => [:group,       :capture,       '(',    0,  1,  0, 0, 0],
     1 => [:literal,     :literal,       '{',    1,  2,  1, 0, 0],

--- a/spec/parser/quantifiers_spec.rb
+++ b/spec/parser/quantifiers_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe('Quantifier parsing') do
   include_examples 'quantifier', /a{4}b/,    '{4}',    :greedy,     :interval,     4, 4
   include_examples 'quantifier', /a{4}?b/,   '{4}?',   :reluctant,  :interval,     4, 4
   include_examples 'quantifier', /a{4}+b/,   '{4}+',   :possessive, :interval,     4, 4
+  include_examples 'quantifier', /a{004}+b/, '{004}+', :possessive, :interval,     4, 4
 
   specify('mode-checking methods') do
     exp = RP.parse(/a??/).first

--- a/spec/scanner/delimiters_spec.rb
+++ b/spec/scanner/delimiters_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+RSpec.describe('Literal delimiter scanning') do
+  include_examples 'scan', '}',
+    0 => [:literal,     :literal,       '}',        0,  1]
+
+  include_examples 'scan', '}}',
+    0 => [:literal,     :literal,       '}}',       0,  2]
+
+  include_examples 'scan', '{',
+    0 => [:literal,     :literal,       '{',        0,  1]
+
+  include_examples 'scan', '{{',
+    0 => [:literal,     :literal,       '{{',       0,  2]
+
+  include_examples 'scan', '{}',
+    0 => [:literal,     :literal,       '{}',       0,  2]
+
+  include_examples 'scan', '}{',
+    0 => [:literal,     :literal,       '}{',       0,  2]
+
+  include_examples 'scan', '}{+',
+    0 => [:literal,     :literal,       '}{',       0,  2]
+
+  include_examples 'scan', '{{var}}',
+    0 => [:literal,     :literal,       '{{var}}',  0,  7]
+
+  include_examples 'scan', '({.+})',
+    0 => [:group,       :capture,       '(',        0,  1],
+    1 => [:literal,     :literal,       '{',        1,  2],
+    2 => [:meta,        :dot,           '.',        2,  3],
+    3 => [:quantifier,  :one_or_more,   '+',        3,  4],
+    4 => [:literal,     :literal,       '}',        4,  5],
+    5 => [:group,       :close,         ')',        5,  6]
+
+  include_examples 'scan', ']',
+    0 => [:literal,     :literal,       ']',        0,  1]
+
+  include_examples 'scan', ']]',
+    0 => [:literal,     :literal,       ']]',       0,  2]
+
+  include_examples 'scan', ']\[',
+    0 => [:literal,     :literal,       ']',        0,  1],
+    1 => [:escape,      :set_open,      '\[',       1,  3]
+
+  include_examples 'scan', '()',
+    0 => [:group,       :capture,       '(',        0,  1],
+    1 => [:group,       :close,         ')',        1,  2]
+end

--- a/spec/scanner/delimiters_spec.rb
+++ b/spec/scanner/delimiters_spec.rb
@@ -25,6 +25,9 @@ RSpec.describe('Literal delimiter scanning') do
   include_examples 'scan', '{{var}}',
     0 => [:literal,     :literal,       '{{var}}',  0,  7]
 
+  include_examples 'scan', 'a{1,2',
+    0 => [:literal,     :literal,       'a{1,2',    0,  5]
+
   include_examples 'scan', '({.+})',
     0 => [:group,       :capture,       '(',        0,  1],
     1 => [:literal,     :literal,       '{',        1,  2],

--- a/spec/scanner/errors_spec.rb
+++ b/spec/scanner/errors_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe(Regexp::Scanner) do
   include_examples 'scan error', RS::PrematureEndError, 'unbalanced set', '[a'
   include_examples 'scan error', RS::PrematureEndError, 'unbalanced set', '[[:alpha:]'
   include_examples 'scan error', RS::PrematureEndError, 'unbalanced group', '(abc'
-  include_examples 'scan error', RS::PrematureEndError, 'unbalanced interval', 'a{1,2'
   include_examples 'scan error', RS::PrematureEndError, 'eof in property', '\p{asci'
   include_examples 'scan error', RS::PrematureEndError, 'incomplete property', '\p{ascii abc'
   include_examples 'scan error', RS::PrematureEndError, 'eof options', '(?mix'


### PR DESCRIPTION
Interprets the `{`, `}`, and `]` delimiters as literals depending on the context.

_Notes_
- Reduce ambiguity in the `quantifier_interval` pattern by replacing the optional matchers with 4 fixed patterns.
- Remove the `premature_end_error` final state handler from `quantifier_interval` to permit valid literal sequences.

Closes #63 