### PR TITLE
Add simple handling/workaround for chained quantifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
 
 - `Regexp::Expression::Base#base_length`
   * returns the character count of an expression body, ignoring any quantifier
+- pragmatic, experimental support for chained quantifiers
+  * e.g.: `/^a{10}{4,6}$/` matches exactly 40, 50 or 60 `a`s
+  * successive quantifiers used to be silently dropped by the parser
+  * they are now wrapped with passive groups as if they were written `(?:a{10}){4,6}`
+  * thanks to [calfeld](https://github.com/calfeld) for reporting this a while back
 
 ### Fixed
 

--- a/lib/regexp_parser/expression/classes/group.rb
+++ b/lib/regexp_parser/expression/classes/group.rb
@@ -10,9 +10,24 @@ module Regexp::Expression
       def comment?; false end
     end
 
-    class Atomic  < Group::Base; end
-    class Passive < Group::Base; end
+    class Passive < Group::Base
+      attr_writer :implicit
+
+      def to_s(format = :full)
+        if implicit?
+          "#{expressions.join}#{quantifier_affix(format)}"
+        else
+          super
+        end
+      end
+
+      def implicit?
+        @implicit ||= false
+      end
+    end
+
     class Absence < Group::Base; end
+    class Atomic  < Group::Base; end
     class Options < Group::Base
       attr_accessor :option_changes
     end

--- a/lib/regexp_parser/expression/quantifier.rb
+++ b/lib/regexp_parser/expression/quantifier.rb
@@ -40,5 +40,14 @@ module Regexp::Expression
       RUBY
     end
     alias :lazy? :reluctant?
+
+    def ==(other)
+      other.class == self.class &&
+        other.token == token &&
+        other.mode == mode &&
+        other.min == min &&
+        other.max == max
+    end
+    alias :eq :==
   end
 end

--- a/spec/expression/to_s_spec.rb
+++ b/spec/expression/to_s_spec.rb
@@ -98,6 +98,13 @@ RSpec.describe('Expression#to_s') do
     expect(Regexp.new(root.to_s, Regexp::EXTENDED).match(str)[0]).to eq multiline.match(str)[0]
   end
 
+  # special case: implicit groups used for chained quantifiers produce no parens
+  specify 'chained quantifiers #to_s' do
+    pattern = /a+{1}{2}/
+    root = RP.parse(pattern)
+    expect(root.to_s).to eq 'a+{1}{2}'
+  end
+
   # regression test for https://github.com/ammar/regexp_parser/issues/74
   specify('non-ascii comment') do
     pattern = '(?x) 😋 # 😋'

--- a/spec/parser/quantifiers_spec.rb
+++ b/spec/parser/quantifiers_spec.rb
@@ -37,6 +37,21 @@ RSpec.describe('Quantifier parsing') do
   include_examples 'quantifier', /a{4}+b/,   '{4}+',   :possessive, :interval,     4, 4
   include_examples 'quantifier', /a{004}+b/, '{004}+', :possessive, :interval,     4, 4
 
+  # special case: exps with chained quantifiers are wrapped in implicit passive groups
+  include_examples 'parse', /a+{2}{3}/,
+    0 => [
+      :group, :passive, Group::Passive, implicit?: true, level: 0,
+      quantifier: Quantifier.new(:interval, '{3}', 3, 3, :greedy)
+    ],
+    [0, 0] => [
+      :group, :passive, Group::Passive, implicit?: true, level: 1,
+      quantifier: Quantifier.new(:interval, '{2}', 2, 2, :greedy)
+    ],
+    [0, 0, 0] => [
+      :literal, :literal, Literal, text: 'a', level: 2,
+      quantifier: Quantifier.new(:one_or_more, '+', 1, -1, :greedy)
+    ]
+
   specify('mode-checking methods') do
     exp = RP.parse(/a??/).first
 

--- a/spec/scanner/quantifiers_spec.rb
+++ b/spec/scanner/quantifiers_spec.rb
@@ -1,20 +1,25 @@
 require 'spec_helper'
 
 RSpec.describe('Quantifier scanning') do
-  include_examples 'scan', 'a?',     1 => [:quantifier,  :zero_or_one,             '?',     1, 2]
-  include_examples 'scan', 'a??',    1 => [:quantifier,  :zero_or_one_reluctant,   '??',    1, 3]
-  include_examples 'scan', 'a?+',    1 => [:quantifier,  :zero_or_one_possessive,  '?+',    1, 3]
+  include_examples 'scan', 'a?',       1 => [:quantifier,  :zero_or_one,             '?',     1, 2]
+  include_examples 'scan', 'a??',      1 => [:quantifier,  :zero_or_one_reluctant,   '??',    1, 3]
+  include_examples 'scan', 'a?+',      1 => [:quantifier,  :zero_or_one_possessive,  '?+',    1, 3]
 
-  include_examples 'scan', 'a*',     1 => [:quantifier,  :zero_or_more,            '*',     1, 2]
-  include_examples 'scan', 'a*?',    1 => [:quantifier,  :zero_or_more_reluctant,  '*?',    1, 3]
-  include_examples 'scan', 'a*+',    1 => [:quantifier,  :zero_or_more_possessive, '*+',    1, 3]
+  include_examples 'scan', 'a*',       1 => [:quantifier,  :zero_or_more,            '*',     1, 2]
+  include_examples 'scan', 'a*?',      1 => [:quantifier,  :zero_or_more_reluctant,  '*?',    1, 3]
+  include_examples 'scan', 'a*+',      1 => [:quantifier,  :zero_or_more_possessive, '*+',    1, 3]
 
-  include_examples 'scan', 'a+',     1 => [:quantifier,  :one_or_more,             '+',     1, 2]
-  include_examples 'scan', 'a+?',    1 => [:quantifier,  :one_or_more_reluctant,   '+?',    1, 3]
-  include_examples 'scan', 'a++',    1 => [:quantifier,  :one_or_more_possessive,  '++',    1, 3]
+  include_examples 'scan', 'a+',       1 => [:quantifier,  :one_or_more,             '+',     1, 2]
+  include_examples 'scan', 'a+?',      1 => [:quantifier,  :one_or_more_reluctant,   '+?',    1, 3]
+  include_examples 'scan', 'a++',      1 => [:quantifier,  :one_or_more_possessive,  '++',    1, 3]
 
-  include_examples 'scan', 'a{2}',   1 => [:quantifier,  :interval,                '{2}',   1, 4]
-  include_examples 'scan', 'a{2,}',  1 => [:quantifier,  :interval,                '{2,}',  1, 5]
-  include_examples 'scan', 'a{,2}',  1 => [:quantifier,  :interval,                '{,2}',  1, 5]
-  include_examples 'scan', 'a{2,4}', 1 => [:quantifier,  :interval,                '{2,4}', 1, 6]
+  include_examples 'scan', 'a{2}',     1 => [:quantifier,  :interval,                '{2}',   1, 4]
+  include_examples 'scan', 'a{2,}',    1 => [:quantifier,  :interval,                '{2,}',  1, 5]
+  include_examples 'scan', 'a{,2}',    1 => [:quantifier,  :interval,                '{,2}',  1, 5]
+  include_examples 'scan', 'a{2,4}',   1 => [:quantifier,  :interval,                '{2,4}', 1, 6]
+
+  # special case: chained quantifiers
+  include_examples 'scan', 'a+{2}{3}', 1 => [:quantifier,  :one_or_more,             '+',     1, 2]
+  include_examples 'scan', 'a+{2}{3}', 2 => [:quantifier,  :interval,                '{2}',   2, 5]
+  include_examples 'scan', 'a+{2}{3}', 3 => [:quantifier,  :interval,                '{3}',   5, 8]
 end


### PR DESCRIPTION
@ammar wanna take a look?

this adds support for chained quantifiers by wrapping their targets in passive groups.

it modifies the node tree while parsing, similar to the treatment of alternations, ranges in sets etc.

this seems to be the most pragmatic way to handle these edge cases. existing integrations of the gem will keep working without effort, and if someone really wants to treat these cases in a special way, they can check `#implicit?`.

i also explored some other approaches, which seemed worse:

1. allowing `Quantifier` objects to have a `#quantifier` themselves
  - this would mirror Onigmo, where quantifiers are normal nodes and can thus have a quantifier (via a pointer)
  - this is bad IMO because it hides the problem: people will not usually check this method and existing implementations certainly don't

2. replacing `#quantifier` with `#quantifiers` returning an Array of `Quantifier` objects for all expressions
  - this is really bad because:
  - everyone using the gem has to update the integration
  - everyone building an integration will have to understand the obscure reason for this pluralization

3. same as `2`, but leaving `def quantifier; quantifiers[0] end` as a fallback
  - this either suffers the same issue of hiding the problem as `1`
  - or, if there is a deprecation warning, it forces people to think and decide about this very edgy case