### PR TITLE
Don't modify range for Ruby 2.7+

### DIFF
--- a/lib/regexp_parser/expression.rb
+++ b/lib/regexp_parser/expression.rb
@@ -81,7 +81,9 @@ module Regexp::Expression
       min = quantifier.min
       max = quantifier.max < 0 ? Float::INFINITY : quantifier.max
       # fix Range#minmax - https://bugs.ruby-lang.org/issues/15807
-      (min..max).tap { |r| r.define_singleton_method(:minmax) { [min, max] } }
+      (min..max).tap do |r|
+        r.define_singleton_method(:minmax) { [min, max] } unless RUBY_VERSION.to_f > 2.6
+      end
     end
 
     def greedy?


### PR DESCRIPTION
Ranges are frozen by default in Ruby 3 which prevents patching in minmax here- since the issue this patch works around was fixed in Ruby 2.7 don't patch where not needed.