### PR TITLE
Provide character- instead of byte-based indices ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-## [Unreleased]
+## [Unreleased 2.0.0]
+
+### Changed
+
+- some methods that used to return byte-based indices now return char-based indices
+  * the returned values have only changed for Regexps that contain non-ascii chars
+  * this is only a breaking change if you used such methods directly AND relied on them pointing to bytes
+  * affected methods:
+  * `Regexp::Token` `#length`, `#offset`, `#te`, `#ts`
+  * `Regexp::Expression::Base` `#full_length`, `#offset`, `#starts_at`, `#te`, `#ts`
 
 ### Added
 

--- a/lib/regexp_parser/lexer.rb
+++ b/lib/regexp_parser/lexer.rb
@@ -96,10 +96,10 @@ class Regexp::Lexer
 
     tokens.pop
     tokens << Regexp::Token.new(:literal, :literal, lead,
-              token.ts, (token.te - last.bytesize),
+              token.ts, (token.te - last.length),
               nesting, set_nesting, conditional_nesting)
     tokens << Regexp::Token.new(:literal, :literal, last,
-              (token.ts + lead.bytesize), token.te,
+              (token.ts + lead.length), token.te,
               nesting, set_nesting, conditional_nesting)
   end
 

--- a/lib/regexp_parser/scanner/char_type.rl
+++ b/lib/regexp_parser/scanner/char_type.rl
@@ -10,17 +10,17 @@
   # --------------------------------------------------------------------------
   char_type := |*
     char_type_char {
-      case text = text(data, ts, te, 1).first
-      when '\d'; emit(:type, :digit,      text, ts - 1, te)
-      when '\D'; emit(:type, :nondigit,   text, ts - 1, te)
-      when '\h'; emit(:type, :hex,        text, ts - 1, te)
-      when '\H'; emit(:type, :nonhex,     text, ts - 1, te)
-      when '\s'; emit(:type, :space,      text, ts - 1, te)
-      when '\S'; emit(:type, :nonspace,   text, ts - 1, te)
-      when '\w'; emit(:type, :word,       text, ts - 1, te)
-      when '\W'; emit(:type, :nonword,    text, ts - 1, te)
-      when '\R'; emit(:type, :linebreak,  text, ts - 1, te)
-      when '\X'; emit(:type, :xgrapheme,  text, ts - 1, te)
+      case text = copy(data, ts-1, te)
+      when '\d'; emit(:type, :digit,      text)
+      when '\D'; emit(:type, :nondigit,   text)
+      when '\h'; emit(:type, :hex,        text)
+      when '\H'; emit(:type, :nonhex,     text)
+      when '\s'; emit(:type, :space,      text)
+      when '\S'; emit(:type, :nonspace,   text)
+      when '\w'; emit(:type, :word,       text)
+      when '\W'; emit(:type, :nonword,    text)
+      when '\R'; emit(:type, :linebreak,  text)
+      when '\X'; emit(:type, :xgrapheme,  text)
       end
       fret;
     };

--- a/lib/regexp_parser/scanner/property.rl
+++ b/lib/regexp_parser/scanner/property.rl
@@ -14,7 +14,7 @@
   unicode_property := |*
 
     property_sequence < eof(premature_property_end) {
-      text = text(data, ts, te, 1).first
+      text = copy(data, ts-1, te)
       type = (text[1] == 'P') ^ (text[3] == '^') ? :nonproperty : :property
 
       name = data[ts+2..te-2].pack('c*').gsub(/[\^\s_\-]/, '').downcase
@@ -22,7 +22,7 @@
       token = self.class.short_prop_map[name] || self.class.long_prop_map[name]
       raise UnknownUnicodePropertyError.new(name) unless token
 
-      self.emit(type, token.to_sym, text, ts-1, te)
+      self.emit(type, token.to_sym, text)
 
       fret;
     };

--- a/spec/lexer/literals_spec.rb
+++ b/spec/lexer/literals_spec.rb
@@ -10,67 +10,42 @@ RSpec.describe('Literal lexing') do
     1 => [:literal,     :literal,       'b',        1, 2, 0, 0, 0],
     2 => [:quantifier,  :one_or_more,   '+',        2, 3, 0, 0, 0]
 
-  # 2 byte wide characters, Arabic
-  include_examples 'lex', 'ا',
-    0 => [:literal,     :literal,       'ا',        0, 2, 0, 0, 0]
-
-  include_examples 'lex', 'aاbبcت',
-    0 => [:literal,     :literal,       'aاbبcت',   0, 9, 0, 0, 0]
-
-  include_examples 'lex', 'aاbبت?',
-    0 => [:literal,     :literal,       'aاbب',     0, 6, 0, 0, 0],
-    1 => [:literal,     :literal,       'ت',        6, 8, 0, 0, 0],
-    2 => [:quantifier,  :zero_or_one,   '?',        8, 9, 0, 0, 0]
-
-  include_examples 'lex', 'aا?bبcت+',
-    0 => [:literal,     :literal,       'a',        0, 1, 0, 0, 0],
-    1 => [:literal,     :literal,       'ا',        1, 3, 0, 0, 0],
-    2 => [:quantifier,  :zero_or_one,   '?',        3, 4, 0, 0, 0],
-    3 => [:literal,     :literal,       'bبc',      4, 8, 0, 0, 0],
-    4 => [:literal,     :literal,       'ت',        8, 10, 0, 0, 0],
-    5 => [:quantifier,  :one_or_more,   '+',        10, 11, 0, 0, 0]
-
-  include_examples 'lex', 'a(اbب+)cت?',
-    0 => [:literal,     :literal,       'a',        0, 1, 0, 0, 0],
-    1 => [:group,       :capture,       '(',        1, 2, 0, 0, 0],
-    2 => [:literal,     :literal,       'اb',       2, 5, 1, 0, 0],
-    3 => [:literal,     :literal,       'ب',        5, 7, 1, 0, 0],
-    4 => [:quantifier,  :one_or_more,   '+',        7, 8, 1, 0, 0],
-    5 => [:group,       :close,         ')',        8, 9, 0, 0, 0],
-    6 => [:literal,     :literal,       'c',        9, 10, 0, 0, 0],
-    7 => [:literal,     :literal,       'ت',        10, 12, 0, 0, 0],
-    8 => [:quantifier,  :zero_or_one,   '?',        12, 13, 0, 0, 0]
+  # 2 byte wide characters
+  include_examples 'lex', 'äöü+',
+    0 => [:literal,     :literal,       'äö',       0, 2, 0, 0, 0],
+    1 => [:literal,     :literal,       'ü',        2, 3, 0, 0, 0],
+    2 => [:quantifier,  :one_or_more,   '+',        3, 4, 0, 0, 0]
 
   # 3 byte wide characters, Japanese
   include_examples 'lex', 'ab?れます+cd',
     0 => [:literal,     :literal,       'a',        0, 1, 0, 0, 0],
     1 => [:literal,     :literal,       'b',        1, 2, 0, 0, 0],
     2 => [:quantifier,  :zero_or_one,   '?',        2, 3, 0, 0, 0],
-    3 => [:literal,     :literal,       'れま',     3, 9, 0, 0, 0],
-    4 => [:literal,     :literal,       'す',       9, 12, 0, 0, 0],
-    5 => [:quantifier,  :one_or_more,   '+',        12, 13, 0, 0, 0],
-    6 => [:literal,     :literal,       'cd',       13, 15, 0, 0, 0]
+    3 => [:literal,     :literal,       'れま',     3, 5, 0, 0, 0],
+    4 => [:literal,     :literal,       'す',       5, 6, 0, 0, 0],
+    5 => [:quantifier,  :one_or_more,   '+',        6, 7, 0, 0, 0],
+    6 => [:literal,     :literal,       'cd',       7, 9, 0, 0, 0]
 
   # 4 byte wide characters, Osmanya
   include_examples 'lex', '𐒀𐒁?𐒂ab+𐒃',
-    0 => [:literal,     :literal,       '𐒀',        0, 4, 0, 0, 0],
-    1 => [:literal,     :literal,       '𐒁',        4, 8, 0, 0, 0],
-    2 => [:quantifier,  :zero_or_one,   '?',        8, 9, 0, 0, 0],
-    3 => [:literal,     :literal,       '𐒂a',       9, 14, 0, 0, 0],
-    4 => [:literal,     :literal,       'b',        14, 15, 0, 0, 0],
-    5 => [:quantifier,  :one_or_more,   '+',        15, 16, 0, 0, 0],
-    6 => [:literal,     :literal,       '𐒃',        16, 20, 0, 0, 0]
+    0 => [:literal,     :literal,       '𐒀',        0, 1, 0, 0, 0],
+    1 => [:literal,     :literal,       '𐒁',        1, 2, 0, 0, 0],
+    2 => [:quantifier,  :zero_or_one,   '?',        2, 3, 0, 0, 0],
+    3 => [:literal,     :literal,       '𐒂a',       3, 5, 0, 0, 0],
+    4 => [:literal,     :literal,       'b',        5, 6, 0, 0, 0],
+    5 => [:quantifier,  :one_or_more,   '+',        6, 7, 0, 0, 0],
+    6 => [:literal,     :literal,       '𐒃',        7, 8, 0, 0, 0]
 
   include_examples 'lex', 'mu𝄞?si*𝄫c+',
     0 => [:literal,     :literal,       'mu',       0, 2, 0, 0, 0],
-    1 => [:literal,     :literal,       '𝄞',        2, 6, 0, 0, 0],
-    2 => [:quantifier,  :zero_or_one,   '?',        6, 7, 0, 0, 0],
-    3 => [:literal,     :literal,       's',        7, 8, 0, 0, 0],
-    4 => [:literal,     :literal,       'i',        8, 9, 0, 0, 0],
-    5 => [:quantifier,  :zero_or_more,  '*',        9, 10, 0, 0, 0],
-    6 => [:literal,     :literal,       '𝄫',        10, 14, 0, 0, 0],
-    7 => [:literal,     :literal,       'c',        14, 15, 0, 0, 0],
-    8 => [:quantifier,  :one_or_more,   '+',        15, 16, 0, 0, 0]
+    1 => [:literal,     :literal,       '𝄞',        2, 3, 0, 0, 0],
+    2 => [:quantifier,  :zero_or_one,   '?',        3, 4, 0, 0, 0],
+    3 => [:literal,     :literal,       's',        4, 5, 0, 0, 0],
+    4 => [:literal,     :literal,       'i',        5, 6, 0, 0, 0],
+    5 => [:quantifier,  :zero_or_more,  '*',        6, 7, 0, 0, 0],
+    6 => [:literal,     :literal,       '𝄫',        7, 8, 0, 0, 0],
+    7 => [:literal,     :literal,       'c',        8, 9, 0, 0, 0],
+    8 => [:quantifier,  :one_or_more,   '+',        9, 10, 0, 0, 0]
 
   specify('lex single 2 byte char') do
     tokens = RL.lex("\u0627+")

--- a/spec/scanner/literals_spec.rb
+++ b/spec/scanner/literals_spec.rb
@@ -2,48 +2,38 @@ require 'spec_helper'
 
 RSpec.describe('UTF8 scanning') do
   # ascii, single byte characters
-  include_examples 'scan', 'a', 0              => [:literal,     :literal,       'a',        0, 1]
+  include_examples 'scan', 'a',
+    0 => [:literal,     :literal,       'a',        0, 1]
 
-  include_examples 'scan', 'ab+', 0            => [:literal,     :literal,       'ab',       0, 2]
-  include_examples 'scan', 'ab+', 1            => [:quantifier,  :one_or_more,   '+',        2, 3]
+  include_examples 'scan', 'ab+',
+    0 => [:literal,     :literal,       'ab',       0, 2],
+    1 => [:quantifier,  :one_or_more,   '+',        2, 3]
 
-  # 2 byte wide characters, Arabic
-  include_examples 'scan', 'aاbبcت', 0         => [:literal,     :literal,       'aاbبcت',   0, 9]
-
-  include_examples 'scan', 'aاbبت?', 0         => [:literal,     :literal,       'aاbبت',    0, 8]
-  include_examples 'scan', 'aاbبت?', 1         => [:quantifier,  :zero_or_one,   '?',        8, 9]
-
-  include_examples 'scan', 'aا?bبcت+', 0       => [:literal,     :literal,       'aا',       0, 3]
-  include_examples 'scan', 'aا?bبcت+', 1       => [:quantifier,  :zero_or_one,   '?',        3, 4]
-  include_examples 'scan', 'aا?bبcت+', 2       => [:literal,     :literal,       'bبcت',     4, 10]
-  include_examples 'scan', 'aا?bبcت+', 3       => [:quantifier,  :one_or_more,   '+',        10, 11]
-
-  include_examples 'scan', 'a(اbب+)cت?', 0     => [:literal,     :literal,       'a',        0, 1]
-  include_examples 'scan', 'a(اbب+)cت?', 1     => [:group,       :capture,       '(',        1, 2]
-  include_examples 'scan', 'a(اbب+)cت?', 2     => [:literal,     :literal,       'اbب',      2, 7]
-  include_examples 'scan', 'a(اbب+)cت?', 3     => [:quantifier,  :one_or_more,   '+',        7, 8]
-  include_examples 'scan', 'a(اbب+)cت?', 4     => [:group,       :close,         ')',        8, 9]
-  include_examples 'scan', 'a(اbب+)cت?', 5     => [:literal,     :literal,       'cت',       9, 12]
-  include_examples 'scan', 'a(اbب+)cت?', 6     => [:quantifier,  :zero_or_one,   '?',        12, 13]
+  # 2 byte wide characters
+  include_examples 'scan', 'äöü',
+    0 => [:literal,     :literal,        'äöü',     0, 3]
 
   # 3 byte wide characters, Japanese
-  include_examples 'scan', 'ab?れます+cd', 0    => [:literal,     :literal,       'ab',       0, 2]
-  include_examples 'scan', 'ab?れます+cd', 1    => [:quantifier,  :zero_or_one,   '?',        2, 3]
-  include_examples 'scan', 'ab?れます+cd', 2    => [:literal,     :literal,       'れます',    3, 12]
-  include_examples 'scan', 'ab?れます+cd', 3    => [:quantifier,  :one_or_more,   '+',        12, 13]
-  include_examples 'scan', 'ab?れます+cd', 4    => [:literal,     :literal,       'cd',       13, 15]
+  include_examples 'scan', 'ab?れます+cd',
+    0 => [:literal,     :literal,       'ab',       0, 2],
+    1 => [:quantifier,  :zero_or_one,   '?',        2, 3],
+    2 => [:literal,     :literal,       'れます',    3, 6],
+    3 => [:quantifier,  :one_or_more,   '+',        6, 7],
+    4 => [:literal,     :literal,       'cd',       7, 9]
 
   # 4 byte wide characters, Osmanya
-  include_examples 'scan', '𐒀𐒁?𐒂ab+𐒃', 0      => [:literal,     :literal,       '𐒀𐒁',       0, 8]
-  include_examples 'scan', '𐒀𐒁?𐒂ab+𐒃', 1      => [:quantifier,  :zero_or_one,   '?',        8, 9]
-  include_examples 'scan', '𐒀𐒁?𐒂ab+𐒃', 2      => [:literal,     :literal,       '𐒂ab',      9, 15]
-  include_examples 'scan', '𐒀𐒁?𐒂ab+𐒃', 3      => [:quantifier,  :one_or_more,   '+',        15, 16]
-  include_examples 'scan', '𐒀𐒁?𐒂ab+𐒃', 4      => [:literal,     :literal,       '𐒃',        16, 20]
+  include_examples 'scan', '𐒀𐒁?𐒂ab+𐒃',
+    0 => [:literal,     :literal,       '𐒀𐒁',       0, 2],
+    1 => [:quantifier,  :zero_or_one,   '?',        2, 3],
+    2 => [:literal,     :literal,       '𐒂ab',      3, 6],
+    3 => [:quantifier,  :one_or_more,   '+',        6, 7],
+    4 => [:literal,     :literal,       '𐒃',        7, 8]
 
-  include_examples 'scan', 'mu𝄞?si*𝄫c+', 0      => [:literal,     :literal,       'mu𝄞',       0, 6]
-  include_examples 'scan', 'mu𝄞?si*𝄫c+', 1      => [:quantifier,  :zero_or_one,   '?',        6, 7]
-  include_examples 'scan', 'mu𝄞?si*𝄫c+', 2      => [:literal,     :literal,       'si',       7, 9]
-  include_examples 'scan', 'mu𝄞?si*𝄫c+', 3      => [:quantifier,  :zero_or_more,  '*',        9, 10]
-  include_examples 'scan', 'mu𝄞?si*𝄫c+', 4      => [:literal,     :literal,       '𝄫c',       10, 15]
-  include_examples 'scan', 'mu𝄞?si*𝄫c+', 5      => [:quantifier,  :one_or_more,   '+',        15, 16]
+  include_examples 'scan', 'mu𝄞?si*𝄫c+',
+    0 => [:literal,     :literal,       'mu𝄞',       0, 3],
+    1 => [:quantifier,  :zero_or_one,   '?',        3, 4],
+    2 => [:literal,     :literal,       'si',       4, 6],
+    3 => [:quantifier,  :zero_or_more,  '*',        6, 7],
+    4 => [:literal,     :literal,       '𝄫c',       7, 9],
+    5 => [:quantifier,  :one_or_more,   '+',        9, 10]
 end

--- a/spec/scanner/sets_spec.rb
+++ b/spec/scanner/sets_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe('Set scanning') do
   include_examples 'scan', /[<]/,                   1 => [:literal, :literal,        '<',          1, 2]
   include_examples 'scan', /[>]/,                   1 => [:literal, :literal,        '>',          1, 2]
 
-  include_examples 'scan', /[äöü]/,                 2 => [:literal, :literal,        'ö',          3, 5]
-
   include_examples 'scan', /[\x20]/,                1 => [:escape, :hex,             '\x20',       1, 5]
 
   include_examples 'scan', '[\.]',                  1 => [:escape, :dot,             '\.',         1, 3]
@@ -89,6 +87,14 @@ RSpec.describe('Set scanning') do
     6 => [:set,    :negate,          '^',          7, 8],
     8 => [:set,    :range,           '-',          9, 10],
     10=> [:set,    :close,           ']',          11, 12]
+
+  # multi-byte characters should not affect indices
+  include_examples 'scan', /[れます]/,
+    0 => [:set,     :open,           '[',          0, 1],
+    1 => [:literal, :literal,        'れ',          1, 2],
+    2 => [:literal, :literal,        'ま',          2, 3],
+    3 => [:literal, :literal,        'す',          3, 4],
+    4 => [:set,     :close,          ']',          4, 5]
 
   specify('set literal encoding') do
     text = RS.scan('[a]')[1][2].to_s


### PR DESCRIPTION
Ragel runs with byte-based indices (ts, te). These are of little value to end-users, so I suggest we keep track of char-based indices and emit those instead.

c.f. #72