### PR TITLE
Support `#to_s` on frozen Group::Passive

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem 'ice_nine', '~> 0.11.2'
   gem 'rake', '~> 13.0'
   gem 'regexp_property_values', '~> 1.0'
   gem 'rspec', '~> 3.8'

--- a/lib/regexp_parser/expression/classes/group.rb
+++ b/lib/regexp_parser/expression/classes/group.rb
@@ -13,6 +13,11 @@ module Regexp::Expression
     class Passive < Group::Base
       attr_writer :implicit
 
+      def initialize(*)
+        @implicit = false
+        super
+      end
+
       def to_s(format = :full)
         if implicit?
           "#{expressions.join}#{quantifier_affix(format)}"
@@ -22,7 +27,7 @@ module Regexp::Expression
       end
 
       def implicit?
-        @implicit ||= false
+        @implicit
       end
     end
 

--- a/spec/expression/to_s_spec.rb
+++ b/spec/expression/to_s_spec.rb
@@ -1,58 +1,50 @@
 require 'spec_helper'
 
 RSpec.describe('Expression#to_s') do
-  specify('literal alternation') do
-    pattern = 'abcd|ghij|klmn|pqur'
+  def parse_frozen(pattern, ruby_version = nil)
+    IceNine.deep_freeze(RP.parse(pattern, *ruby_version))
+  end
 
-    expect(RP.parse(pattern).to_s).to eq pattern
+  def expect_round_trip(pattern, ruby_version = nil)
+    parsed = parse_frozen(pattern, ruby_version)
+
+    expect(parsed.to_s).to eql(pattern)
+  end
+
+  specify('literal alternation') do
+    expect_round_trip('abcd|ghij|klmn|pqur')
   end
 
   specify('quantified alternations') do
-    pattern = '(?:a?[b]+(c){2}|d+[e]*(f)?)|(?:g+[h]?(i){2,3}|j*[k]{3,5}(l)?)'
-
-    expect(RP.parse(pattern).to_s).to eq pattern
+    expect_round_trip('(?:a?[b]+(c){2}|d+[e]*(f)?)|(?:g+[h]?(i){2,3}|j*[k]{3,5}(l)?)')
   end
 
   specify('quantified sets') do
-    pattern = '[abc]+|[^def]{3,6}'
-
-    expect(RP.parse(pattern).to_s).to eq pattern
+    expect_round_trip('[abc]+|[^def]{3,6}')
   end
 
   specify('property sets') do
-    pattern = '[\\a\\b\\p{Lu}\\P{Z}\\c\\d]+'
-
-    expect(RP.parse(pattern, 'ruby/1.9').to_s).to eq pattern
+    expect_round_trip('[\\a\\b\\p{Lu}\\P{Z}\\c\\d]+', 'ruby/1.9')
   end
 
   specify('groups') do
-    pattern = "(a(?>b(?:c(?<n>d(?'N'e)??f)+g)*+h)*i)++"
-
-    expect(RP.parse(pattern, 'ruby/1.9').to_s).to eq pattern
+    expect_round_trip("(a(?>b(?:c(?<n>d(?'N'e)??f)+g)*+h)*i)++", 'ruby/1.9')
   end
 
   specify('assertions') do
-    pattern = '(a+(?=b+(?!c+(?<=d+(?<!e+)?f+)?g+)?h+)?i+)?'
-
-    expect(RP.parse(pattern, 'ruby/1.9').to_s).to eq pattern
+    expect_round_trip('(a+(?=b+(?!c+(?<=d+(?<!e+)?f+)?g+)?h+)?i+)?', 'ruby/1.9')
   end
 
   specify('comments') do
-    pattern = '(?#start)a(?#middle)b(?#end)'
-
-    expect(RP.parse(pattern).to_s).to eq pattern
+    expect_round_trip('(?#start)a(?#middle)b(?#end)')
   end
 
   specify('options') do
-    pattern = '(?mix:start)a(?-mix:middle)b(?i-mx:end)'
-
-    expect(RP.parse(pattern).to_s).to eq pattern
+    expect_round_trip('(?mix:start)a(?-mix:middle)b(?i-mx:end)')
   end
 
   specify('url') do
-    pattern = ('(^$)|(^(http|https):\\/\\/[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*' + '\\.[a-z]{2,5}(([0-9]{1,5})?\\/.*)?$)')
-
-    expect(RP.parse(pattern).to_s).to eq pattern
+    expect_round_trip('(^$)|(^(http|https):\\/\\/[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*' + '\\.[a-z]{2,5}(([0-9]{1,5})?\\/.*)?$)')
   end
 
   specify('multiline source') do
@@ -64,7 +56,7 @@ RSpec.describe('Expression#to_s') do
           \z
         /x
 
-    expect(RP.parse(multiline).to_s).to eq multiline.source
+    expect(parse_frozen(multiline).to_s).to eql(multiline.source)
   end
 
   specify('multiline #to_s') do
@@ -76,7 +68,7 @@ RSpec.describe('Expression#to_s') do
           \z
         /x
 
-    expect(RP.parse(multiline.to_s).to_s).to eq multiline.to_s
+    expect_round_trip(multiline.to_s)
   end
 
   # Free spacing expressions that use spaces between quantifiers and their
@@ -93,24 +85,24 @@ RSpec.describe('Expression#to_s') do
         /x
 
     str = 'bbbcged'
-    root = RP.parse(multiline)
+    root = parse_frozen(multiline)
 
-    expect(Regexp.new(root.to_s, Regexp::EXTENDED).match(str)[0]).to eq multiline.match(str)[0]
+    expect(Regexp.new(root.to_s, Regexp::EXTENDED).match(str)[0]).to eql(multiline.match(str)[0])
   end
 
   # special case: implicit groups used for chained quantifiers produce no parens
   specify 'chained quantifiers #to_s' do
     pattern = /a+{1}{2}/
-    root = RP.parse(pattern)
-    expect(root.to_s).to eq 'a+{1}{2}'
+    root = parse_frozen(pattern)
+    expect(root.to_s).to eql('a+{1}{2}')
   end
 
   # regression test for https://github.com/ammar/regexp_parser/issues/74
   specify('non-ascii comment') do
     pattern = '(?x) 😋 # 😋'
     root = RP.parse(pattern)
-    expect(root.last).to be_a Regexp::Expression::Comment
-    expect(root.last.to_s).to eq '# 😋'
-    expect(root.to_s).to eq pattern
+    expect(root.last).to be_a(Regexp::Expression::Comment)
+    expect(root.last.to_s).to eql('# 😋')
+    expect(root.to_s).to eql(pattern)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'ice_nine'
 require 'regexp_parser'
 require 'regexp_property_values'
 require_relative 'support/shared_examples'


### PR DESCRIPTION
On [mutant](https://github.com/mbj/mutant) we aggressively freeze objects and work with immutable structures. In trying to [re-introduce support](https://github.com/mbj/mutant/pull/1166) for (immutably) mutating regular expressions I ran into an issue with the 2.x series of `regexp_parser` that prevented calling `#to_s` on frozen passive groups. The change I am having trouble with was introduced [here](https://github.com/ammar/regexp_parser/commit/f14a36bff6fef3ef174b63c744c556469a42a589#diff-5bfe3942df5a59a97d7e5c7d3e918a1c704f964685e719c178af22401da46c23R25).

I am proposing a simple fix here that should hopefully not impact anything else but does allow calling `#to_s` on a frozen passive group.

@jaynetics could you let me know what you think about this issue/approach? Thanks again with your help on the last two issues.