### PR TITLE
Misc. cleanup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ end
 
 namespace :ragel do
   desc "Process the ragel source files and output ruby code"
-  task :rb do |t|
+  task :rb do
     RAGEL_SOURCE_FILES.each do |file|
       output_file = "#{RAGEL_OUTPUT_DIR}/#{file}.rb"
       # using faster flat table driven FSM, about 25% larger code, but about 30% faster
@@ -42,7 +42,7 @@ namespace :ragel do
   end
 
   desc "Delete the ragel generated source file(s)"
-  task :clean do |t|
+  task :clean do
     RAGEL_SOURCE_FILES.each do |file|
       sh "rm -f #{RAGEL_OUTPUT_DIR}/#{file}.rb"
     end

--- a/lib/regexp_parser/expression/classes/free_space.rb
+++ b/lib/regexp_parser/expression/classes/free_space.rb
@@ -1,7 +1,7 @@
 module Regexp::Expression
 
   class FreeSpace < Regexp::Expression::Base
-    def quantify(token, text, min = nil, max = nil, mode = :greedy)
+    def quantify(_token, _text, _min = nil, _max = nil, _mode = :greedy)
       raise "Can not quantify a free space object"
     end
   end

--- a/lib/regexp_parser/expression/methods/match_length.rb
+++ b/lib/regexp_parser/expression/methods/match_length.rb
@@ -10,7 +10,7 @@ class Regexp::MatchLength
     self.exp_class = exp.class
     self.min_rep = exp.repetitions.min
     self.max_rep = exp.repetitions.max
-    if base = opts[:base]
+    if (base = opts[:base])
       self.base_min = base
       self.base_max = base
       self.reify = ->{ '.' * base }

--- a/lib/regexp_parser/expression/methods/match_length.rb
+++ b/lib/regexp_parser/expression/methods/match_length.rb
@@ -32,7 +32,7 @@ class Regexp::MatchLength
     end
   end
 
-  def endless_each(&block)
+  def endless_each
     return enum_for(__method__) unless block_given?
     (min..max).each { |num| yield(num) if include?(num) }
   end

--- a/lib/regexp_parser/expression/methods/traverse.rb
+++ b/lib/regexp_parser/expression/methods/traverse.rb
@@ -36,7 +36,7 @@ module Regexp::Expression
 
     # Iterates over the expressions of this expression as an array, passing
     # the expression and its index within its parent to the given block.
-    def each_expression(include_self = false, &block)
+    def each_expression(include_self = false)
       return enum_for(__method__, include_self) unless block_given?
 
       traverse(include_self) do |event, exp, index|
@@ -47,7 +47,7 @@ module Regexp::Expression
     # Returns a new array with the results of calling the given block once
     # for every expression. If a block is not given, returns an array with
     # each expression and its level index as an array.
-    def flat_map(include_self = false, &block)
+    def flat_map(include_self = false)
       result = []
 
       each_expression(include_self) do |exp, index|

--- a/lib/regexp_parser/syntax/any.rb
+++ b/lib/regexp_parser/syntax/any.rb
@@ -8,8 +8,8 @@ module Regexp::Syntax
       @implements = { :* => [:*] }
     end
 
-    def implements?(type, token) true end
-    def implements!(type, token) true end
+    def implements?(_type, _token) true end
+    def implements!(_type, _token) true end
   end
 
 end

--- a/spec/expression/subexpression_spec.rb
+++ b/spec/expression/subexpression_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe(Regexp::Expression::Subexpression) do
     }
 
     root.each_expression do |exp|
-      next unless expected_nesting_level = tests.delete(exp.to_s)
+      next unless (expected_nesting_level = tests.delete(exp.to_s))
       expect(expected_nesting_level).to eq exp.nesting_level
     end
 

--- a/spec/parser/errors_spec.rb
+++ b/spec/parser/errors_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe('Parsing errors') do
       .to raise_error(Regexp::Parser::UnknownTokenTypeError)
   end
 
-  RSpec.shared_examples 'UnknownTokenError' do |type, token|
+  RSpec.shared_examples 'UnknownTokenError' do |type|
     it "raises for unkown tokens of type #{type}" do
       expect { parser.send(:parse_token, Regexp::Token.new(type, :foo)) }
         .to raise_error(Regexp::Parser::UnknownTokenError)

--- a/spec/parser/quantifiers_spec.rb
+++ b/spec/parser/quantifiers_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe('Quantifier parsing') do
       expect(exp.quantifier.min).to eq min
       expect(exp.quantifier.max).to eq max
       expect(exp.quantifier.mode).to eq mode
+      expect(exp.quantifier.text).to eq text
     end
   end
 


### PR DESCRIPTION
I noticed there was an unused variable in the quantifier spec when I was trying to find a spot to write tests for #77. I think it was meant to be used as an assertion so I added it in the first commit here.

Since I noticed that unused variable by chance, I decided to run `rubocop --lint` and found a few other minor issues that felt like they might be worth a quick fixup. Feel free to reject these changes or I can drop commits you don't like but I thought they were all small improvements.

You might consider adding a minimal `rubocop` config with some basic linting and such enabled to avoid small items like these if you like these changes. If you don't, that's fine too.
