### PR TITLE
Add Ruby 3.0 to CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [ '2.3', '2.4', '2.5', '2.6', '2.7', 'ruby-head' ]
+        ruby: [ '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', 'ruby-head' ]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR just adds Ruby 3.0 to the CI test matrix.