### PR TITLE
Opt-in for MFA requirement explicitly

### DIFF
--- a/regexp_parser.gemspec
+++ b/regexp_parser.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = spec.homepage
   spec.metadata['wiki_uri']        = "#{spec.homepage}/wiki"
 
+  spec.metadata['rubygems_mfa_required'] = 'true'
+
   spec.authors       = ['Ammar Ali', 'Janosch Müller']
   spec.email         = ['ammarabuali@gmail.com', 'janosch84@gmail.com']
 


### PR DESCRIPTION
As a pupular gem, `regexp_parser` implicitly requires that all
privileged operations by any of the owners require OTP.

However, by explicitly setting `rubygems_mfa_required` metadata, the
gem will show "NEW VERSIONS REQUIRE MFA" and
"VERSION PUBLISHED WITH MFA" in the sidebar at
https://github.com/ammar/regexp_parser

Ref:
- https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html
- https://guides.rubygems.org/mfa-requirement-opt-in/
