### PR TITLE
Fix typos

### DIFF
--- a/lib/regexp_parser/expression/classes/keep.rb
+++ b/lib/regexp_parser/expression/classes/keep.rb
@@ -1,6 +1,6 @@
 module Regexp::Expression
   module Keep
-    # TOOD: in regexp_parser v3.0.0 this should possibly be a Subexpression
+    # TODO: in regexp_parser v3.0.0 this should possibly be a Subexpression
     #       that contains all expressions to its left.
     class Mark < Regexp::Expression::Base; end
   end

--- a/lib/regexp_parser/parser.rb
+++ b/lib/regexp_parser/parser.rb
@@ -575,18 +575,18 @@ class Regexp::Parser
     options_stack.last
   end
 
-  # Assigns referenced expressions to refering expressions, e.g. if there is
+  # Assigns referenced expressions to referring expressions, e.g. if there is
   # an instance of Backreference::Number, its #referenced_expression is set to
   # the instance of Group::Capture that it refers to via its number.
   def assign_referenced_expressions
-    # find all referencable and refering expressions
+    # find all referenceable and referring expressions
     targets = { 0 => root }
     referrers = []
     root.each_expression do |exp|
       exp.is_a?(Group::Capture) && targets[exp.identifier] = exp
       referrers << exp if exp.referential?
     end
-    # assign reference expression to refering expressions
+    # assign reference expression to referring expressions
     # (in a second iteration because there might be forward references)
     referrers.each do |exp|
       exp.referenced_expression = targets[exp.reference] ||

--- a/spec/parser/errors_spec.rb
+++ b/spec/parser/errors_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe('Parsing errors') do
   end
 
   RSpec.shared_examples 'UnknownTokenError' do |type|
-    it "raises for unkown tokens of type #{type}" do
+    it "raises for unknown tokens of type #{type}" do
       expect { parser.send(:parse_token, Regexp::Token.new(type, :foo)) }
         .to raise_error(Regexp::Parser::UnknownTokenError)
     end

--- a/spec/parser/escapes_spec.rb
+++ b/spec/parser/escapes_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe('EscapeSequence parsing') do
     expect { exp.codepoint }.to raise_error(/#codepoints/)
   end
 
-  # Meta/control espaces
+  # Meta/control escapes
   #
   # After the following fix in Ruby 3.1, a Regexp#source containing meta/control
   # escapes can only be set with the Regexp::new constructor.

--- a/spec/scanner/escapes_spec.rb
+++ b/spec/scanner/escapes_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe('Escape scanning') do
   include_examples 'scan', /a\
 b/x,                                          0 => [:literal,  :literal,         'ab',             0,  2]
 
-  # Meta/control espaces
+  # Meta/control escapes
   #
   # After the following fix in Ruby 3.1, a Regexp#source containing meta/control
   # escapes can only be set with the Regexp::new constructor.

--- a/spec/scanner/refcalls_spec.rb
+++ b/spec/scanner/refcalls_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe('RefCall scanning') do
   #
   # NOTE: only \g supports forward-looking references using '+', e.g. \g<+1>
   # refers to the next group, but \k<+1> refers to a group named '+1'.
-  # Inversely, only \k supports addition or substraction of a recursion level.
+  # Inversely, only \k supports addition or subtraction of a recursion level.
   # E.g. \k<x+0> refers to a group named 'x' at the current recursion level,
   # but \g<x+0> refers to a a group named 'x+0'.
   #


### PR DESCRIPTION
```
codespell **/*.rb **/*.md -w -L te,vai,cant,serch
```