### PR TITLE
Update scanner.rl to not treat lookbehinds with literal `<` characters as named groups

### DIFF
--- a/lib/regexp_parser/scanner/scanner.rl
+++ b/lib/regexp_parser/scanner/scanner.rl
@@ -78,7 +78,7 @@
   # try to treat every other group head as options group, like Ruby
   group_options         = '?' . ( [^!#'():<=>~]+ . ':'? ) ?;
 
-  group_name_id_ab      = ([^!0-9\->] | utf8_multibyte) . ([^>] | utf8_multibyte)*;
+  group_name_id_ab      = ([^!=0-9\->] | utf8_multibyte) . ([^>] | utf8_multibyte)*;
   group_name_id_sq      = ([^0-9\-']  | utf8_multibyte) . ([^'] | utf8_multibyte)*;
   group_number          = '-'? . [0-9]+;
   group_level           = [+\-] . [0-9]+;

--- a/spec/scanner/groups_spec.rb
+++ b/spec/scanner/groups_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe('Group scanning') do
   include_examples 'scan', '(?<!abc)',        0 => [:assertion, :nlookbehind,    '(?<!',       0, 4]
   include_examples 'scan', '(?<!x)y>',        0 => [:assertion, :nlookbehind,    '(?<!',       0, 4]
   include_examples 'scan', '(?<!x>)y',        0 => [:assertion, :nlookbehind,    '(?<!',       0, 4]
+  include_examples 'scan', '(?<=x>)y',        0 => [:assertion, :lookbehind,     '(?<=',       0, 4]
 
   # Options
   include_examples 'scan', '(?-mix:abc)',     0 => [:group,     :options,        '(?-mix:',    0, 7]


### PR DESCRIPTION
Previously, positive lookbehinds that contained literal `<` characters were erroneously tokenized as named groups instead of assertions. This fixes that to ensure that lookbehinds are treated as assertions.

This bug affects rubocop: https://github.com/rubocop/rubocop/issues/13511

Fixes #93.