### PR TITLE
Enable Frozen String Literals

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,11 @@ jobs:
       matrix:
         ruby: [ '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'ruby-head' ]
 
+    env:
+      # The RUBYOPT flags can be removed if RuboCop style checks are added
+      # to the lint workflow and support for Ruby < 2.3 is dropped.
+      RUBYOPT: '--enable=frozen-string-literal --debug=frozen-string-literal'
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          rubygems: latest
           bundler-cache: true
       - name: Install ragel
         run: sudo apt-get install -yqq ragel

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler'
 require 'rubygems'
 require 'rubygems/package_task'

--- a/lib/regexp_parser.rb
+++ b/lib/regexp_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'regexp_parser/version'
 require_relative 'regexp_parser/token'
 require_relative 'regexp_parser/scanner'

--- a/lib/regexp_parser/error.rb
+++ b/lib/regexp_parser/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::Parser
   # base class for all gem-specific errors
   class Error < StandardError; end

--- a/lib/regexp_parser/expression.rb
+++ b/lib/regexp_parser/expression.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'error'
 
 require_relative 'expression/shared'

--- a/lib/regexp_parser/expression/base.rb
+++ b/lib/regexp_parser/expression/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   class Base
     include Regexp::Expression::Shared

--- a/lib/regexp_parser/expression/classes/alternation.rb
+++ b/lib/regexp_parser/expression/classes/alternation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   # A sequence of expressions, used by Alternation as one of its alternatives.
   class Alternative < Regexp::Expression::Sequence; end

--- a/lib/regexp_parser/expression/classes/anchor.rb
+++ b/lib/regexp_parser/expression/classes/anchor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   module Anchor
     class Base < Regexp::Expression::Base; end

--- a/lib/regexp_parser/expression/classes/backreference.rb
+++ b/lib/regexp_parser/expression/classes/backreference.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   module Backreference
     class Base < Regexp::Expression::Base; end

--- a/lib/regexp_parser/expression/classes/character_set.rb
+++ b/lib/regexp_parser/expression/classes/character_set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   class CharacterSet < Regexp::Expression::Subexpression
     attr_accessor :closed, :negative

--- a/lib/regexp_parser/expression/classes/character_set/intersection.rb
+++ b/lib/regexp_parser/expression/classes/character_set/intersection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   class CharacterSet < Regexp::Expression::Subexpression
     class IntersectedSequence < Regexp::Expression::Sequence; end

--- a/lib/regexp_parser/expression/classes/character_set/range.rb
+++ b/lib/regexp_parser/expression/classes/character_set/range.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   class CharacterSet < Regexp::Expression::Subexpression
     class Range < Regexp::Expression::Subexpression

--- a/lib/regexp_parser/expression/classes/character_type.rb
+++ b/lib/regexp_parser/expression/classes/character_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   module CharacterType
     class Base < Regexp::Expression::Base; end

--- a/lib/regexp_parser/expression/classes/conditional.rb
+++ b/lib/regexp_parser/expression/classes/conditional.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   module Conditional
     class TooManyBranches < Regexp::Parser::Error

--- a/lib/regexp_parser/expression/classes/escape_sequence.rb
+++ b/lib/regexp_parser/expression/classes/escape_sequence.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   module EscapeSequence
     Base        = Class.new(Regexp::Expression::Base)

--- a/lib/regexp_parser/expression/classes/free_space.rb
+++ b/lib/regexp_parser/expression/classes/free_space.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   class FreeSpace < Regexp::Expression::Base
     def quantify(*_args)

--- a/lib/regexp_parser/expression/classes/group.rb
+++ b/lib/regexp_parser/expression/classes/group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   module Group
     class Base < Regexp::Expression::Subexpression

--- a/lib/regexp_parser/expression/classes/keep.rb
+++ b/lib/regexp_parser/expression/classes/keep.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   module Keep
     # TODO: in regexp_parser v3.0.0 this should possibly be a Subexpression

--- a/lib/regexp_parser/expression/classes/literal.rb
+++ b/lib/regexp_parser/expression/classes/literal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   class Literal < Regexp::Expression::Base; end
 end

--- a/lib/regexp_parser/expression/classes/posix_class.rb
+++ b/lib/regexp_parser/expression/classes/posix_class.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   class PosixClass < Regexp::Expression::Base
     def name

--- a/lib/regexp_parser/expression/classes/root.rb
+++ b/lib/regexp_parser/expression/classes/root.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   class Root < Regexp::Expression::Subexpression
     def self.build(options = {})

--- a/lib/regexp_parser/expression/classes/unicode_property.rb
+++ b/lib/regexp_parser/expression/classes/unicode_property.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   module UnicodeProperty
     class Base < Regexp::Expression::Base

--- a/lib/regexp_parser/expression/methods/construct.rb
+++ b/lib/regexp_parser/expression/methods/construct.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   module Shared
     module ClassMethods

--- a/lib/regexp_parser/expression/methods/escape_sequence_char.rb
+++ b/lib/regexp_parser/expression/methods/escape_sequence_char.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Regexp::Expression::EscapeSequence::Base.class_eval do
   def char
     codepoint.chr('utf-8')

--- a/lib/regexp_parser/expression/methods/escape_sequence_codepoint.rb
+++ b/lib/regexp_parser/expression/methods/escape_sequence_codepoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression::EscapeSequence
   AsciiEscape.class_eval { def codepoint; 0x1B end }
   Backspace.class_eval   { def codepoint; 0x8  end }

--- a/lib/regexp_parser/expression/methods/human_name.rb
+++ b/lib/regexp_parser/expression/methods/human_name.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   module Shared
     # default implementation, e.g. "atomic group", "hex escape", "word type", ..

--- a/lib/regexp_parser/expression/methods/match.rb
+++ b/lib/regexp_parser/expression/methods/match.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   class Base
     def match?(string)

--- a/lib/regexp_parser/expression/methods/match_length.rb
+++ b/lib/regexp_parser/expression/methods/match_length.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::MatchLength
   include Enumerable
 

--- a/lib/regexp_parser/expression/methods/negative.rb
+++ b/lib/regexp_parser/expression/methods/negative.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   module Shared
     def negative?

--- a/lib/regexp_parser/expression/methods/options.rb
+++ b/lib/regexp_parser/expression/methods/options.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   class Base
     def multiline?

--- a/lib/regexp_parser/expression/methods/parts.rb
+++ b/lib/regexp_parser/expression/methods/parts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   module Shared
     # default implementation

--- a/lib/regexp_parser/expression/methods/printing.rb
+++ b/lib/regexp_parser/expression/methods/printing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   module Shared
     def inspect

--- a/lib/regexp_parser/expression/methods/referenced_expressions.rb
+++ b/lib/regexp_parser/expression/methods/referenced_expressions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   module ReferencedExpressions
     attr_accessor :referenced_expressions

--- a/lib/regexp_parser/expression/methods/strfregexp.rb
+++ b/lib/regexp_parser/expression/methods/strfregexp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   class Base
 

--- a/lib/regexp_parser/expression/methods/tests.rb
+++ b/lib/regexp_parser/expression/methods/tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   module Shared
 

--- a/lib/regexp_parser/expression/methods/traverse.rb
+++ b/lib/regexp_parser/expression/methods/traverse.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   class Subexpression < Regexp::Expression::Base
 

--- a/lib/regexp_parser/expression/quantifier.rb
+++ b/lib/regexp_parser/expression/quantifier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   # TODO: in v3.0.0, maybe put Shared back into Base, and inherit from Base and
   # call super in #initialize, but raise in #quantifier= and #quantify,
@@ -6,7 +8,7 @@ module Regexp::Expression
   class Quantifier
     include Regexp::Expression::Shared
 
-    MODES = %i[greedy possessive reluctant]
+    MODES = %i[greedy possessive reluctant].freeze
 
     def initialize(*args)
       deprecated_old_init(*args) and return if args.count == 4 || args.count == 5

--- a/lib/regexp_parser/expression/sequence.rb
+++ b/lib/regexp_parser/expression/sequence.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   # A sequence of expressions. Differs from a Subexpressions by how it handles
   # quantifiers, as it applies them to its last element instead of itself as

--- a/lib/regexp_parser/expression/sequence_operation.rb
+++ b/lib/regexp_parser/expression/sequence_operation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   # abstract class
   class SequenceOperation < Regexp::Expression::Subexpression

--- a/lib/regexp_parser/expression/shared.rb
+++ b/lib/regexp_parser/expression/shared.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   module Shared
     module ClassMethods; end # filled in ./methods/*.rb

--- a/lib/regexp_parser/expression/subexpression.rb
+++ b/lib/regexp_parser/expression/subexpression.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Expression
   class Subexpression < Regexp::Expression::Base
     include Enumerable

--- a/lib/regexp_parser/lexer.rb
+++ b/lib/regexp_parser/lexer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A very thin wrapper around the scanner that breaks quantified literal runs,
 # collects emitted tokens into an array, calculates their nesting depth, and
 # normalizes tokens for the parser, and checks if they are implemented by the

--- a/lib/regexp_parser/parser.rb
+++ b/lib/regexp_parser/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'error'
 require_relative 'expression'
 

--- a/lib/regexp_parser/scanner/errors/premature_end_error.rb
+++ b/lib/regexp_parser/scanner/errors/premature_end_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::Scanner
   # Unexpected end of pattern
   class PrematureEndError < ScannerError

--- a/lib/regexp_parser/scanner/errors/scanner_error.rb
+++ b/lib/regexp_parser/scanner/errors/scanner_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../regexp_parser/error'
 
 class Regexp::Scanner

--- a/lib/regexp_parser/scanner/errors/validation_error.rb
+++ b/lib/regexp_parser/scanner/errors/validation_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::Scanner
   # Base for all scanner validation errors
   class ValidationError < ScannerError

--- a/lib/regexp_parser/syntax.rb
+++ b/lib/regexp_parser/syntax.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'error'
 
 module Regexp::Syntax

--- a/lib/regexp_parser/syntax/any.rb
+++ b/lib/regexp_parser/syntax/any.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Syntax
   # A syntax that always returns true, passing all tokens as implemented. This
   # is useful during development, testing, and should be useful for some types

--- a/lib/regexp_parser/syntax/base.rb
+++ b/lib/regexp_parser/syntax/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Syntax
   class NotImplementedError < Regexp::Syntax::SyntaxError
     def initialize(syntax, type, token)

--- a/lib/regexp_parser/syntax/token.rb
+++ b/lib/regexp_parser/syntax/token.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 # Define the base module and the simplest of tokens.
 module Regexp::Syntax
   module Token
-    Map = {}
+    Map = Hash.new
 
     module Literal
-      All = %i[literal]
+      All = %i[literal].freeze
       Type = :literal
     end
 
     module FreeSpace
-      All  = %i[comment whitespace]
+      All  = %i[comment whitespace].freeze
       Type = :free_space
     end
 

--- a/lib/regexp_parser/syntax/token/anchor.rb
+++ b/lib/regexp_parser/syntax/token/anchor.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module Regexp::Syntax
   module Token
     module Anchor
-      Basic       = %i[bol eol]
+      Basic       = %i[bol eol].freeze
       Extended    = Basic + %i[word_boundary nonword_boundary]
-      String      = %i[bos eos eos_ob_eol]
-      MatchStart  = %i[match_start]
+      String      = %i[bos eos eos_ob_eol].freeze
+      MatchStart  = %i[match_start].freeze
 
       All = Extended + String + MatchStart
       Type = :anchor

--- a/lib/regexp_parser/syntax/token/assertion.rb
+++ b/lib/regexp_parser/syntax/token/assertion.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module Regexp::Syntax
   module Token
     module Assertion
-      Lookahead = %i[lookahead nlookahead]
-      Lookbehind = %i[lookbehind nlookbehind]
+      Lookahead = %i[lookahead nlookahead].freeze
+      Lookbehind = %i[lookbehind nlookbehind].freeze
 
       All = Lookahead + Lookbehind
       Type = :assertion

--- a/lib/regexp_parser/syntax/token/backreference.rb
+++ b/lib/regexp_parser/syntax/token/backreference.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 module Regexp::Syntax
   module Token
     module Backreference
-      Plain     = %i[number]
-      NumberRef = %i[number_ref number_rel_ref]
+      Plain     = %i[number].freeze
+      NumberRef = %i[number_ref number_rel_ref].freeze
       Number    = Plain + NumberRef
-      Name      = %i[name_ref]
+      Name      = %i[name_ref].freeze
 
-      RecursionLevel = %i[name_recursion_ref number_recursion_ref]
+      RecursionLevel = %i[name_recursion_ref number_recursion_ref].freeze
 
       V1_8_6 = Plain
 
@@ -18,8 +20,8 @@ module Regexp::Syntax
 
     # Type is the same as Backreference so keeping it here, for now.
     module SubexpressionCall
-      Name      = %i[name_call]
-      Number    = %i[number_call number_rel_call]
+      Name      = %i[name_call].freeze
+      Number    = %i[number_call number_rel_call].freeze
 
       All = Name + Number
     end

--- a/lib/regexp_parser/syntax/token/character_set.rb
+++ b/lib/regexp_parser/syntax/token/character_set.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Regexp::Syntax
   module Token
     module CharacterSet
-      Basic     = %i[open close negate range]
+      Basic     = %i[open close negate range].freeze
       Extended  = Basic + %i[intersection]
 
       All = Extended

--- a/lib/regexp_parser/syntax/token/character_type.rb
+++ b/lib/regexp_parser/syntax/token/character_type.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 module Regexp::Syntax
   module Token
     module CharacterType
-      Basic     = []
-      Extended  = %i[digit nondigit space nonspace word nonword]
-      Hex       = %i[hex nonhex]
+      Basic     = [].freeze
+      Extended  = %i[digit nondigit space nonspace word nonword].freeze
+      Hex       = %i[hex nonhex].freeze
 
-      Clustered = %i[linebreak xgrapheme]
+      Clustered = %i[linebreak xgrapheme].freeze
 
       All = Basic + Extended + Hex + Clustered
       Type = :type

--- a/lib/regexp_parser/syntax/token/conditional.rb
+++ b/lib/regexp_parser/syntax/token/conditional.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module Regexp::Syntax
   module Token
     module Conditional
-      Delimiters = %i[open close]
+      Delimiters = %i[open close].freeze
 
-      Condition  = %i[condition_open condition condition_close]
-      Separator  = %i[separator]
+      Condition  = %i[condition_open condition condition_close].freeze
+      Separator  = %i[separator].freeze
 
       All = Conditional::Delimiters + Conditional::Condition + Conditional::Separator
 

--- a/lib/regexp_parser/syntax/token/escape.rb
+++ b/lib/regexp_parser/syntax/token/escape.rb
@@ -1,25 +1,27 @@
+# frozen_string_literal: true
+
 module Regexp::Syntax
   module Token
     module Escape
-      Basic = %i[backslash literal]
+      Basic = %i[backslash literal].freeze
 
-      Control = %i[control meta_sequence]
+      Control = %i[control meta_sequence].freeze
 
       ASCII = %i[bell backspace escape form_feed newline carriage
-                 tab vertical_tab]
+                 tab vertical_tab].freeze
 
-      Unicode = %i[codepoint codepoint_list]
+      Unicode = %i[codepoint codepoint_list].freeze
 
       Meta  = %i[dot alternation
                  zero_or_one zero_or_more one_or_more
                  bol eol
                  group_open group_close
                  interval_open interval_close
-                 set_open set_close]
+                 set_open set_close].freeze
 
-      Hex   = %i[hex utf8_hex]
+      Hex   = %i[hex utf8_hex].freeze
 
-      Octal = %i[octal]
+      Octal = %i[octal].freeze
 
       All   = Basic + Control + ASCII + Unicode + Meta + Hex + Octal
       Type  = :escape

--- a/lib/regexp_parser/syntax/token/group.rb
+++ b/lib/regexp_parser/syntax/token/group.rb
@@ -1,18 +1,20 @@
+# frozen_string_literal: true
+
 module Regexp::Syntax
   module Token
     module Group
-      Basic     = %i[capture close]
+      Basic     = %i[capture close].freeze
       Extended  = Basic + %i[options options_switch]
 
-      Named     = %i[named]
-      Atomic    = %i[atomic]
-      Passive   = %i[passive]
-      Comment   = %i[comment]
+      Named     = %i[named].freeze
+      Atomic    = %i[atomic].freeze
+      Passive   = %i[passive].freeze
+      Comment   = %i[comment].freeze
 
       V1_8_6 = Group::Extended + Group::Named + Group::Atomic +
                Group::Passive + Group::Comment
 
-      V2_4_1 = %i[absence]
+      V2_4_1 = %i[absence].freeze
 
       All = V1_8_6 + V2_4_1
       Type = :group

--- a/lib/regexp_parser/syntax/token/keep.rb
+++ b/lib/regexp_parser/syntax/token/keep.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Regexp::Syntax
   module Token
     module Keep
-      Mark = %i[mark]
+      Mark = %i[mark].freeze
 
       All  = Mark
       Type = :keep

--- a/lib/regexp_parser/syntax/token/meta.rb
+++ b/lib/regexp_parser/syntax/token/meta.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module Regexp::Syntax
   module Token
     module Meta
-      Basic       = %i[dot]
-      Alternation = %i[alternation]
+      Basic       = %i[dot].freeze
+      Alternation = %i[alternation].freeze
       Extended    = Basic + Alternation
 
       All = Extended

--- a/lib/regexp_parser/syntax/token/posix_class.rb
+++ b/lib/regexp_parser/syntax/token/posix_class.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module Regexp::Syntax
   module Token
     module PosixClass
       Standard = %i[alnum alpha blank cntrl digit graph
-                    lower print punct space upper xdigit]
+                    lower print punct space upper xdigit].freeze
 
-      Extensions = %i[ascii word]
+      Extensions = %i[ascii word].freeze
 
       All = Standard + Extensions
       Type = :posixclass

--- a/lib/regexp_parser/syntax/token/quantifier.rb
+++ b/lib/regexp_parser/syntax/token/quantifier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Regexp::Syntax
   module Token
     module Quantifier
@@ -5,23 +7,23 @@ module Regexp::Syntax
         zero_or_one
         zero_or_more
         one_or_more
-      ]
+      ].freeze
 
       Reluctant = %i[
         zero_or_one_reluctant
         zero_or_more_reluctant
         one_or_more_reluctant
-      ]
+      ].freeze
 
       Possessive = %i[
         zero_or_one_possessive
         zero_or_more_possessive
         one_or_more_possessive
-      ]
+      ].freeze
 
-      Interval             = %i[interval]
-      IntervalReluctant    = %i[interval_reluctant]
-      IntervalPossessive   = %i[interval_possessive]
+      Interval             = %i[interval].freeze
+      IntervalReluctant    = %i[interval_reluctant].freeze
+      IntervalPossessive   = %i[interval_possessive].freeze
 
       IntervalAll = Interval + IntervalReluctant + IntervalPossessive
 

--- a/lib/regexp_parser/syntax/token/unicode_property.rb
+++ b/lib/regexp_parser/syntax/token/unicode_property.rb
@@ -1,37 +1,39 @@
+# frozen_string_literal: true
+
 module Regexp::Syntax
   module Token
     module UnicodeProperty
       all = proc { |name| constants.grep(/#{name}/).flat_map(&method(:const_get)) }
 
       CharType_V1_9_0 = %i[alnum alpha ascii blank cntrl digit graph
-                           lower print punct space upper word xdigit]
+                           lower print punct space upper word xdigit].freeze
 
-      CharType_V2_5_0 = %i[xposixpunct]
+      CharType_V2_5_0 = %i[xposixpunct].freeze
 
-      POSIX = %i[any assigned newline]
+      POSIX = %i[any assigned newline].freeze
 
       module Category
         Letter        = %i[letter uppercase_letter lowercase_letter
-                           titlecase_letter modifier_letter other_letter]
+                           titlecase_letter modifier_letter other_letter].freeze
 
         Mark          = %i[mark nonspacing_mark spacing_mark
-                           enclosing_mark]
+                           enclosing_mark].freeze
 
         Number        = %i[number decimal_number letter_number
-                           other_number]
+                           other_number].freeze
 
         Punctuation   = %i[punctuation connector_punctuation dash_punctuation
                            open_punctuation close_punctuation initial_punctuation
-                           final_punctuation other_punctuation]
+                           final_punctuation other_punctuation].freeze
 
         Symbol        = %i[symbol math_symbol currency_symbol
-                           modifier_symbol other_symbol]
+                           modifier_symbol other_symbol].freeze
 
         Separator     = %i[separator space_separator line_separator
-                           paragraph_separator]
+                           paragraph_separator].freeze
 
         Codepoint     = %i[other control format
-                           surrogate private_use unassigned]
+                           surrogate private_use unassigned].freeze
 
         All = Letter + Mark + Number + Punctuation +
               Symbol + Separator + Codepoint
@@ -39,27 +41,27 @@ module Regexp::Syntax
 
       Age_V1_9_3 = %i[age=1.1 age=2.0 age=2.1 age=3.0 age=3.1
                       age=3.2 age=4.0 age=4.1 age=5.0 age=5.1
-                      age=5.2 age=6.0]
+                      age=5.2 age=6.0].freeze
 
-      Age_V2_0_0 = %i[age=6.1]
+      Age_V2_0_0 = %i[age=6.1].freeze
 
-      Age_V2_2_0 = %i[age=6.2 age=6.3 age=7.0]
+      Age_V2_2_0 = %i[age=6.2 age=6.3 age=7.0].freeze
 
-      Age_V2_3_0 = %i[age=8.0]
+      Age_V2_3_0 = %i[age=8.0].freeze
 
-      Age_V2_4_0 = %i[age=9.0]
+      Age_V2_4_0 = %i[age=9.0].freeze
 
-      Age_V2_5_0 = %i[age=10.0]
+      Age_V2_5_0 = %i[age=10.0].freeze
 
-      Age_V2_6_0 = %i[age=11.0]
+      Age_V2_6_0 = %i[age=11.0].freeze
 
-      Age_V2_6_2 = %i[age=12.0]
+      Age_V2_6_2 = %i[age=12.0].freeze
 
-      Age_V2_6_3 = %i[age=12.1]
+      Age_V2_6_3 = %i[age=12.1].freeze
 
-      Age_V3_1_0 = %i[age=13.0]
+      Age_V3_1_0 = %i[age=13.0].freeze
 
-      Age_V3_2_0 = %i[age=14.0 age=15.0]
+      Age_V3_2_0 = %i[age=14.0 age=15.0].freeze
 
       Age = all[:Age_V]
 
@@ -115,20 +117,20 @@ module Regexp::Syntax
         white_space
         xid_start
         xid_continue
-      ]
+      ].freeze
 
       Derived_V2_0_0 = %i[
         cased_letter
         combining_mark
-      ]
+      ].freeze
 
       Derived_V2_4_0 = %i[
         prepended_concatenation_mark
-      ]
+      ].freeze
 
       Derived_V2_5_0 = %i[
         regional_indicator
-      ]
+      ].freeze
 
       Derived = all[:Derived_V]
 
@@ -226,13 +228,13 @@ module Regexp::Syntax
         inherited
         common
         unknown
-      ]
+      ].freeze
 
       Script_V1_9_3 = %i[
         brahmi
         batak
         mandaic
-      ]
+      ].freeze
 
       Script_V2_0_0 = %i[
         chakma
@@ -242,7 +244,7 @@ module Regexp::Syntax
         sharada
         sora_sompeng
         takri
-      ]
+      ].freeze
 
       Script_V2_2_0 = %i[
         caucasian_albanian
@@ -268,7 +270,7 @@ module Regexp::Syntax
         khudawadi
         tirhuta
         warang_citi
-      ]
+      ].freeze
 
       Script_V2_3_0 = %i[
         ahom
@@ -277,7 +279,7 @@ module Regexp::Syntax
         multani
         old_hungarian
         signwriting
-      ]
+      ].freeze
 
       Script_V2_4_0 = %i[
         adlam
@@ -286,14 +288,14 @@ module Regexp::Syntax
         newa
         osage
         tangut
-      ]
+      ].freeze
 
       Script_V2_5_0 = %i[
         masaram_gondi
         nushu
         soyombo
         zanabazar_square
-      ]
+      ].freeze
 
       Script_V2_6_0 = %i[
         dogra
@@ -303,21 +305,21 @@ module Regexp::Syntax
         medefaidrin
         old_sogdian
         sogdian
-      ]
+      ].freeze
 
       Script_V2_6_2 = %i[
         elymaic
         nandinagari
         nyiakeng_puachue_hmong
         wancho
-      ]
+      ].freeze
 
       Script_V3_1_0 = %i[
         chorasmian
         dives_akuru
         khitan_small_script
         yezidi
-      ]
+      ].freeze
 
       Script_V3_2_0 = %i[
         cypro_minoan
@@ -327,7 +329,7 @@ module Regexp::Syntax
         tangsa
         toto
         vithkuqi
-      ]
+      ].freeze
 
       Script = all[:Script_V]
 
@@ -428,7 +430,7 @@ module Regexp::Syntax
         in_yi_radicals
         in_yi_syllables
         in_yijing_hexagram_symbols
-      ]
+      ].freeze
 
       UnicodeBlock_V2_0_0 = %i[
         in_aegean_numbers
@@ -556,7 +558,7 @@ module Regexp::Syntax
         in_variation_selectors_supplement
         in_vedic_extensions
         in_vertical_forms
-      ]
+      ].freeze
 
       UnicodeBlock_V2_2_0 = %i[
         in_bassa_vah
@@ -591,7 +593,7 @@ module Regexp::Syntax
         in_supplemental_arrows_c
         in_tirhuta
         in_warang_citi
-      ]
+      ].freeze
 
       UnicodeBlock_V2_3_0 = %i[
         in_ahom
@@ -604,7 +606,7 @@ module Regexp::Syntax
         in_old_hungarian
         in_supplemental_symbols_and_pictographs
         in_sutton_signwriting
-      ]
+      ].freeze
 
       UnicodeBlock_V2_4_0 = %i[
         in_adlam
@@ -618,7 +620,7 @@ module Regexp::Syntax
         in_osage
         in_tangut
         in_tangut_components
-      ]
+      ].freeze
 
       UnicodeBlock_V2_5_0 = %i[
         in_cjk_unified_ideographs_extension_f
@@ -628,7 +630,7 @@ module Regexp::Syntax
         in_soyombo
         in_syriac_supplement
         in_zanabazar_square
-      ]
+      ].freeze
 
       UnicodeBlock_V2_6_0 = %i[
         in_chess_symbols
@@ -642,7 +644,7 @@ module Regexp::Syntax
         in_medefaidrin
         in_old_sogdian
         in_sogdian
-      ]
+      ].freeze
 
       UnicodeBlock_V2_6_2 = %i[
         in_egyptian_hieroglyph_format_controls
@@ -654,7 +656,7 @@ module Regexp::Syntax
         in_symbols_and_pictographs_extended_a
         in_tamil_supplement
         in_wancho
-      ]
+      ].freeze
 
       UnicodeBlock_V3_1_0 = %i[
         in_chorasmian
@@ -665,7 +667,7 @@ module Regexp::Syntax
         in_symbols_for_legacy_computing
         in_tangut_supplement
         in_yezidi
-      ]
+      ].freeze
 
       UnicodeBlock_V3_2_0 = %i[
         in_arabic_extended_b
@@ -687,7 +689,7 @@ module Regexp::Syntax
         in_unified_canadian_aboriginal_syllabics_extended_a
         in_vithkuqi
         in_znamenny_musical_notation
-      ]
+      ].freeze
 
       UnicodeBlock = all[:UnicodeBlock_V]
 
@@ -697,11 +699,11 @@ module Regexp::Syntax
         emoji_modifier
         emoji_modifier_base
         emoji_presentation
-      ]
+      ].freeze
 
       Emoji_V2_6_0 = %i[
         extended_pictographic
-      ]
+      ].freeze
 
       Enumerated_V2_4_0 = %i[
         grapheme_cluster_break=control
@@ -717,7 +719,7 @@ module Regexp::Syntax
         grapheme_cluster_break=t
         grapheme_cluster_break=v
         grapheme_cluster_break=zwj
-      ]
+      ].freeze
 
       Enumerated = all[:Enumerated_V]
 

--- a/lib/regexp_parser/syntax/token/virtual.rb
+++ b/lib/regexp_parser/syntax/token/virtual.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module Regexp::Syntax
   module Token
     module Virtual
-      Root     = %i[root]
-      Sequence = %i[sequence]
+      Root     = %i[root].freeze
+      Sequence = %i[sequence].freeze
 
-      All  = %i[root sequence]
+      All  = %i[root sequence].freeze
       Type = :expression
     end
   end

--- a/lib/regexp_parser/syntax/version_lookup.rb
+++ b/lib/regexp_parser/syntax/version_lookup.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Regexp::Syntax
   VERSION_FORMAT = '\Aruby/\d+\.\d+(\.\d+)?\z'
-  VERSION_REGEXP = /#{VERSION_FORMAT}/
-  VERSION_CONST_REGEXP = /\AV\d+_\d+(?:_\d+)?\z/
+  VERSION_REGEXP = /#{VERSION_FORMAT}/.freeze
+  VERSION_CONST_REGEXP = /\AV\d+_\d+(?:_\d+)?\z/.freeze
 
   class InvalidVersionNameError < Regexp::Syntax::SyntaxError
     def initialize(name)

--- a/lib/regexp_parser/syntax/versions.rb
+++ b/lib/regexp_parser/syntax/versions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Ruby 1.x is no longer a supported runtime,
 # but its regex features are still recognized.
 #

--- a/lib/regexp_parser/syntax/versions/1.8.6.rb
+++ b/lib/regexp_parser/syntax/versions/1.8.6.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::Syntax::V1_8_6 < Regexp::Syntax::Base
   implements :anchor,     Anchor::All
   implements :assertion,  Assertion::Lookahead

--- a/lib/regexp_parser/syntax/versions/1.9.1.rb
+++ b/lib/regexp_parser/syntax/versions/1.9.1.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::Syntax::V1_9_1 < Regexp::Syntax::V1_8_6
   implements :assertion,     Assertion::Lookbehind
   implements :backref,       Backreference::V1_9_1 + SubexpressionCall::All

--- a/lib/regexp_parser/syntax/versions/1.9.3.rb
+++ b/lib/regexp_parser/syntax/versions/1.9.3.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::Syntax::V1_9_3 < Regexp::Syntax::V1_9_1
   implements :property,    UnicodeProperty::V1_9_3
   implements :nonproperty, UnicodeProperty::V1_9_3

--- a/lib/regexp_parser/syntax/versions/2.0.0.rb
+++ b/lib/regexp_parser/syntax/versions/2.0.0.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::Syntax::V2_0_0 < Regexp::Syntax::V1_9_3
   implements :keep,        Keep::All
   implements :conditional, Conditional::All

--- a/lib/regexp_parser/syntax/versions/2.2.0.rb
+++ b/lib/regexp_parser/syntax/versions/2.2.0.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::Syntax::V2_2_0 < Regexp::Syntax::V2_0_0
   implements :property,    UnicodeProperty::V2_2_0
   implements :nonproperty, UnicodeProperty::V2_2_0

--- a/lib/regexp_parser/syntax/versions/2.3.0.rb
+++ b/lib/regexp_parser/syntax/versions/2.3.0.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::Syntax::V2_3_0 < Regexp::Syntax::V2_2_0
   implements :property,    UnicodeProperty::V2_3_0
   implements :nonproperty, UnicodeProperty::V2_3_0

--- a/lib/regexp_parser/syntax/versions/2.4.0.rb
+++ b/lib/regexp_parser/syntax/versions/2.4.0.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::Syntax::V2_4_0 < Regexp::Syntax::V2_3_0
   implements :property,    UnicodeProperty::V2_4_0
   implements :nonproperty, UnicodeProperty::V2_4_0

--- a/lib/regexp_parser/syntax/versions/2.4.1.rb
+++ b/lib/regexp_parser/syntax/versions/2.4.1.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::Syntax::V2_4_1 < Regexp::Syntax::V2_4_0
   implements :group, Group::V2_4_1
 end

--- a/lib/regexp_parser/syntax/versions/2.5.0.rb
+++ b/lib/regexp_parser/syntax/versions/2.5.0.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::Syntax::V2_5_0 < Regexp::Syntax::V2_4_1
   implements :property,    UnicodeProperty::V2_5_0
   implements :nonproperty, UnicodeProperty::V2_5_0

--- a/lib/regexp_parser/syntax/versions/2.6.0.rb
+++ b/lib/regexp_parser/syntax/versions/2.6.0.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::Syntax::V2_6_0 < Regexp::Syntax::V2_5_0
   implements :property,    UnicodeProperty::V2_6_0
   implements :nonproperty, UnicodeProperty::V2_6_0

--- a/lib/regexp_parser/syntax/versions/2.6.2.rb
+++ b/lib/regexp_parser/syntax/versions/2.6.2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::Syntax::V2_6_2 < Regexp::Syntax::V2_6_0
   implements :property,    UnicodeProperty::V2_6_2
   implements :nonproperty, UnicodeProperty::V2_6_2

--- a/lib/regexp_parser/syntax/versions/2.6.3.rb
+++ b/lib/regexp_parser/syntax/versions/2.6.3.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::Syntax::V2_6_3 < Regexp::Syntax::V2_6_2
   implements :property,    UnicodeProperty::V2_6_3
   implements :nonproperty, UnicodeProperty::V2_6_3

--- a/lib/regexp_parser/syntax/versions/3.1.0.rb
+++ b/lib/regexp_parser/syntax/versions/3.1.0.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::Syntax::V3_1_0 < Regexp::Syntax::V2_6_3
   implements :property,    UnicodeProperty::V3_1_0
   implements :nonproperty, UnicodeProperty::V3_1_0

--- a/lib/regexp_parser/syntax/versions/3.2.0.rb
+++ b/lib/regexp_parser/syntax/versions/3.2.0.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp::Syntax::V3_2_0 < Regexp::Syntax::V3_1_0
   implements :property,    UnicodeProperty::V3_2_0
   implements :nonproperty, UnicodeProperty::V3_2_0

--- a/lib/regexp_parser/token.rb
+++ b/lib/regexp_parser/token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp
   TOKEN_KEYS = %i[
     type

--- a/lib/regexp_parser/version.rb
+++ b/lib/regexp_parser/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Regexp
   class Parser
     VERSION = '2.11.0'

--- a/regexp_parser.gemspec
+++ b/regexp_parser.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $:.unshift File.join(File.dirname(__FILE__), 'lib')
 
 require 'regexp_parser/version'

--- a/spec/expression/base_spec.rb
+++ b/spec/expression/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Expression::Base) do

--- a/spec/expression/clone_spec.rb
+++ b/spec/expression/clone_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Expression::Base#clone') do

--- a/spec/expression/conditional_spec.rb
+++ b/spec/expression/conditional_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Expression::Conditional) do

--- a/spec/expression/free_space_spec.rb
+++ b/spec/expression/free_space_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Expression::FreeSpace) do

--- a/spec/expression/methods/construct_spec.rb
+++ b/spec/expression/methods/construct_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Expression::Shared) do

--- a/spec/expression/methods/human_name_spec.rb
+++ b/spec/expression/methods/human_name_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Regexp::Expression::Shared#human_name') do

--- a/spec/expression/methods/match_length_spec.rb
+++ b/spec/expression/methods/match_length_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 ML = Regexp::MatchLength

--- a/spec/expression/methods/match_spec.rb
+++ b/spec/expression/methods/match_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Expression::Base#match') do

--- a/spec/expression/methods/negative_spec.rb
+++ b/spec/expression/methods/negative_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Expression::Base#negative?') do

--- a/spec/expression/methods/parts_spec.rb
+++ b/spec/expression/methods/parts_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Expression::Base#parts') do

--- a/spec/expression/methods/printing_spec.rb
+++ b/spec/expression/methods/printing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Expression::Shared#inspect') do

--- a/spec/expression/methods/strfregexp_spec.rb
+++ b/spec/expression/methods/strfregexp_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Expression::Base#strfregexp') do

--- a/spec/expression/methods/tests_spec.rb
+++ b/spec/expression/methods/tests_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('ExpressionTests') do

--- a/spec/expression/methods/traverse_spec.rb
+++ b/spec/expression/methods/traverse_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Subexpression#traverse') do

--- a/spec/expression/options_spec.rb
+++ b/spec/expression/options_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Expression::Base#options') do

--- a/spec/expression/subexpression_spec.rb
+++ b/spec/expression/subexpression_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Expression::Subexpression) do

--- a/spec/expression/te_ts_spec.rb
+++ b/spec/expression/te_ts_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Expression::Shared#te,ts') do

--- a/spec/expression/to_h_spec.rb
+++ b/spec/expression/to_h_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Expression::Base#to_h') do

--- a/spec/expression/to_s_spec.rb
+++ b/spec/expression/to_s_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Expression::Base#to_s') do

--- a/spec/lexer/all_spec.rb
+++ b/spec/lexer/all_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Lexer) do

--- a/spec/lexer/conditionals_spec.rb
+++ b/spec/lexer/conditionals_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Conditional lexing') do

--- a/spec/lexer/delimiters_spec.rb
+++ b/spec/lexer/delimiters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Literal delimiter lexing') do

--- a/spec/lexer/escapes_spec.rb
+++ b/spec/lexer/escapes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Escape lexing') do

--- a/spec/lexer/keep_spec.rb
+++ b/spec/lexer/keep_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Keep lexing') do

--- a/spec/lexer/literals_spec.rb
+++ b/spec/lexer/literals_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Literal lexing') do

--- a/spec/lexer/nesting_spec.rb
+++ b/spec/lexer/nesting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Nesting lexing') do

--- a/spec/lexer/refcalls_spec.rb
+++ b/spec/lexer/refcalls_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('RefCall lexing') do

--- a/spec/parser/all_spec.rb
+++ b/spec/parser/all_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Parser) do

--- a/spec/parser/alternation_spec.rb
+++ b/spec/parser/alternation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Alternation parsing') do

--- a/spec/parser/anchors_spec.rb
+++ b/spec/parser/anchors_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Anchor parsing') do

--- a/spec/parser/conditionals_spec.rb
+++ b/spec/parser/conditionals_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Conditional parsing') do

--- a/spec/parser/errors_spec.rb
+++ b/spec/parser/errors_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Parsing errors') do

--- a/spec/parser/escapes_spec.rb
+++ b/spec/parser/escapes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('EscapeSequence parsing') do
@@ -57,7 +59,7 @@ RSpec.describe('EscapeSequence parsing') do
   # In Regexp literals, these escapes are now pre-processed to hex escapes.
   #
   # https://github.com/ruby/ruby/commit/11ae581a4a7f5d5f5ec6378872eab8f25381b1b9
-  n = ->(regexp_body){ Regexp.new(regexp_body.force_encoding('ascii-8bit')) }
+  n = ->(regexp_body){ Regexp.new(regexp_body.dup.force_encoding('ascii-8bit')) }
 
   include_examples 'parse', n.('\\\\\c2b'),  1 => [es::Control,     text: '\c2',     char: "\x12",   codepoint: 18 ]
   include_examples 'parse', n.('\d\C-C\w'),  1 => [es::Control,     text: '\C-C',    char: "\x03",   codepoint: 3  ]

--- a/spec/parser/free_space_spec.rb
+++ b/spec/parser/free_space_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('FreeSpace parsing') do

--- a/spec/parser/groups_spec.rb
+++ b/spec/parser/groups_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Group parsing') do

--- a/spec/parser/keep_spec.rb
+++ b/spec/parser/keep_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Keep parsing') do

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('passing options to parse') do

--- a/spec/parser/posix_classes_spec.rb
+++ b/spec/parser/posix_classes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('PosixClass parsing') do

--- a/spec/parser/properties_spec.rb
+++ b/spec/parser/properties_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Property parsing') do

--- a/spec/parser/quantifiers_spec.rb
+++ b/spec/parser/quantifiers_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Quantifier parsing') do

--- a/spec/parser/refcalls_spec.rb
+++ b/spec/parser/refcalls_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Refcall parsing') do

--- a/spec/parser/set/intersections_spec.rb
+++ b/spec/parser/set/intersections_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 # edge cases with `...-&&...` and `...&&-...` are checked in ./ranges_spec.rb

--- a/spec/parser/set/ranges_spec.rb
+++ b/spec/parser/set/ranges_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('CharacterSet::Range parsing') do

--- a/spec/parser/sets_spec.rb
+++ b/spec/parser/sets_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('CharacterSet parsing') do

--- a/spec/parser/types_spec.rb
+++ b/spec/parser/types_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('CharacterType parsing') do

--- a/spec/scanner/all_spec.rb
+++ b/spec/scanner/all_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Scanner) do

--- a/spec/scanner/anchors_spec.rb
+++ b/spec/scanner/anchors_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Anchor scanning') do

--- a/spec/scanner/conditionals_spec.rb
+++ b/spec/scanner/conditionals_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Conditional scanning') do

--- a/spec/scanner/delimiters_spec.rb
+++ b/spec/scanner/delimiters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Literal delimiter scanning') do

--- a/spec/scanner/errors_spec.rb
+++ b/spec/scanner/errors_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Scanner) do

--- a/spec/scanner/escapes_spec.rb
+++ b/spec/scanner/escapes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Escape scanning') do
@@ -76,7 +78,7 @@ b/x,                                          0 => [:literal,  :literal,        
   # In Regexp literals, these escapes are now pre-processed to hex escapes.
   #
   # https://github.com/ruby/ruby/commit/11ae581a4a7f5d5f5ec6378872eab8f25381b1b9
-  n = ->(regexp_body){ Regexp.new(regexp_body.force_encoding('ascii-8bit')) }
+  n = ->(regexp_body){ Regexp.new(regexp_body.dup.force_encoding('ascii-8bit')) }
 
   include_examples 'scan', 'a\cBc',           1 => [:escape,  :control,          '\cB',            1,  4]
   include_examples 'scan', 'a\c^c',           1 => [:escape,  :control,          '\c^',            1,  4]

--- a/spec/scanner/free_space_spec.rb
+++ b/spec/scanner/free_space_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('FreeSpace scanning') do

--- a/spec/scanner/groups_spec.rb
+++ b/spec/scanner/groups_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Group scanning') do

--- a/spec/scanner/keep_spec.rb
+++ b/spec/scanner/keep_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Keep scanning') do

--- a/spec/scanner/literals_spec.rb
+++ b/spec/scanner/literals_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('UTF-8 scanning') do

--- a/spec/scanner/meta_spec.rb
+++ b/spec/scanner/meta_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Meta scanning') do

--- a/spec/scanner/options_spec.rb
+++ b/spec/scanner/options_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('passing options to scan') do

--- a/spec/scanner/properties_spec.rb
+++ b/spec/scanner/properties_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Property scanning') do

--- a/spec/scanner/quantifiers_spec.rb
+++ b/spec/scanner/quantifiers_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Quantifier scanning') do

--- a/spec/scanner/refcalls_spec.rb
+++ b/spec/scanner/refcalls_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('RefCall scanning') do

--- a/spec/scanner/sets_spec.rb
+++ b/spec/scanner/sets_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Set scanning') do

--- a/spec/scanner/types_spec.rb
+++ b/spec/scanner/types_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe('Type scanning') do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $VERBOSE = true
 
 require 'leto'

--- a/spec/support/capturing_stderr.rb
+++ b/spec/support/capturing_stderr.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 
 def capturing_stderr(&block)

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples 'syntax' do |opts|
   opts[:implements].each do |type, tokens|
     tokens.each do |token|

--- a/spec/syntax/syntax_spec.rb
+++ b/spec/syntax/syntax_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Syntax) do

--- a/spec/syntax/syntax_token_map_spec.rb
+++ b/spec/syntax/syntax_token_map_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Syntax::Token::Map) do

--- a/spec/syntax/versions/1.8.6_spec.rb
+++ b/spec/syntax/versions/1.8.6_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Syntax::V1_8_6) do

--- a/spec/syntax/versions/1.9.1_spec.rb
+++ b/spec/syntax/versions/1.9.1_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Syntax::V1_9_1) do

--- a/spec/syntax/versions/1.9.3_spec.rb
+++ b/spec/syntax/versions/1.9.3_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Syntax::V1_9_3) do

--- a/spec/syntax/versions/2.0.0_spec.rb
+++ b/spec/syntax/versions/2.0.0_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Syntax::V2_0_0) do

--- a/spec/syntax/versions/2.2.0_spec.rb
+++ b/spec/syntax/versions/2.2.0_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Syntax::V2_2_0) do

--- a/spec/syntax/versions/3.2.0_spec.rb
+++ b/spec/syntax/versions/3.2.0_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Syntax::V3_2_0) do

--- a/spec/token/token_spec.rb
+++ b/spec/token/token_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe(Regexp::Token) do

--- a/tasks/benchmark.rake
+++ b/tasks/benchmark.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 BENCHMARKS_DIR = "#{__dir__}/benchmarks"
 
 desc 'Run all IPS benchmarks'

--- a/tasks/benchmarks/minimal_regexp.rb
+++ b/tasks/benchmarks/minimal_regexp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/ips'
 require_relative '../../lib/regexp_parser'
 

--- a/tasks/benchmarks/uri_regexp.rb
+++ b/tasks/benchmarks/uri_regexp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'benchmark/ips'
 require_relative '../../lib/regexp_parser'
 

--- a/tasks/props.rake
+++ b/tasks/props.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :props do
   desc 'Write new property value hashes for the properties scanner'
   task :update do

--- a/tasks/ragel.rake
+++ b/tasks/ragel.rake
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 RAGEL_SOURCE_DIR = File.join(__dir__, '../lib/regexp_parser/scanner')
 RAGEL_OUTPUT_DIR = File.join(__dir__, '../lib/regexp_parser')
-RAGEL_SOURCE_FILES = %w[scanner] # scanner.rl imports the other files
+RAGEL_SOURCE_FILES = %w[scanner].freeze # scanner.rl imports the other files
 
 namespace :ragel do
   desc 'Process the ragel source files and output ruby code'
@@ -22,6 +24,8 @@ namespace :ragel do
 
       File.open(output_path, 'w') do |file|
         file.puts(<<-RUBY.gsub(/^\s+/, ''))
+          # frozen_string_literal: true
+
           # -*- warn-indent:false;  -*-
           #
           # THIS IS A GENERATED FILE, DO NOT EDIT DIRECTLY


### PR DESCRIPTION
~The PR is actually ready, but I'm opening as a draft to wait for some feedback in #96. Please take a look at the note at the end of the commit message~

---

- Add frozen string literal magic comments and apply related style
  corrections using:
  ```
  rubocop --only Style/FrozenStringLiteralComment,Layout/EmptyLineAfterMagicComment,Style/RedundantFreeze,Style/MutableConstant -A
  ```
- Initialize `Map` with `Hash.new` in
  `lib/regexp_parser/syntax/token.rb` to allow mutation. This is the
  only manual change to production code.
- In specs (`parser/escapes_spec.rb`, `scanner/escapes_spec.rb`),
  duplicate strings before applying `force_encoding` to avoid mutation
  errors.
- Ensure Ragel-generated `lib/regexp_parser/scanner.rb` begins with the
  frozen string literal comment.
- Set `RUBYOPT='--enable=frozen-string-literal --debug=frozen-string-literal'`
  in CI to catch regressions.

These updates standardize string immutability, reduce mutation errors,
and improve codebase consistency.

Note: While issue #96 raised concerns about inconsistent benchmark
results and possible slowdowns, further investigation and larger-scale
benchmarks suggest that enabling frozen string literals generally
provides neutral or positive performance, with reduced memory
allocations. Community consensus is that the benefits for code safety
and consistency outweigh the minor or inconsistent regressions observed
in specific cases.
