### PR TITLE
Fix `bundle exec rake install` when `command` is a shell buildin

### DIFF
--- a/tasks/ragel.rake
+++ b/tasks/ragel.rake
@@ -43,12 +43,12 @@ namespace :ragel do
   task :install do
     next if ENV['CI']
 
-    if system('command -v ragel')
+    if system('sh -c "command -v ragel"')
       # already installed
-    elsif system('command -v brew')
+    elsif system('sh -c "command -v brew"')
       puts 'ragel not found, installing with homebrew ...'
       `brew install ragel`
-    elsif system('command -v apt-get')
+    elsif system('sh -c "command -v apt-get"')
       puts 'ragel not found, installing with apt-get ...'
       `sudo apt-get install -y ragel`
     else


### PR DESCRIPTION
When it was part of bin/setup, it was already run via sh. This makes that work again.